### PR TITLE
Update development and support gradle version to 4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ Development
 
 [Code of Conduct](docs/Code-of-conduct.md)
 
+Gradle and Java Compatibility
+=============================
+
+Built with Oracle JDK7
+Tested with Oracle JDK8
+
+| Gradle Version  | Works  |
+| :-------------: | :----: |
+| 4.0             | ![yes] |
+| 4.1             | ![yes] |
+| 4.2             | ![yes] |
+| 4.3             | ![yes] |
+| 4.4             | ![yes] |
+| 4.5             | ![yes] |
+| 4.6             | ![yes] |
+| 4.6             | ![yes] |
+| 4.7             | ![yes] |
+| 4.8             | ![yes] |
+| 4.9             | ![yes] |
+| 4.10            | ![yes] |
+
 LICENSE
 =======
 

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+versions=("4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10")
+
+for i in "${versions[@]}"
+do
+    echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/integrationTest "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+done


### PR DESCRIPTION
## Description

This patch updates the used gradle version for development to `4.10`. This concludes the support of the gradle `4.x` version range as `4.10` is the last version before `5.0`

see wooga/rfcs#2

## Changes

![UPDATE] ![GRADLE] development/support version to `4.10`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
