### PR TITLE
Improve publish logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,5 +10,5 @@ withCredentials([string(credentialsId: 'atlas_hockey_integration_api_token', var
                             "ATLAS_HOCKEY_INTEGRATION_APPLICATION_IDENTIFIER=${hockeyAppId}"
                           ]
 
-    buildGradlePlugin plaforms: ['osx'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    buildGradlePlugin plaforms: ['osx', 'windows'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,3 +38,13 @@ pluginBundle {
 github {
     repositoryName = "wooga/atlas-hockey"
 }
+
+dependencies {
+    testCompile('org.spockframework:spock-core:1.2-groovy-2.4') {
+        exclude module: 'groovy-all'
+    }
+
+    testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
+    compile 'org.apache.httpcomponents:httpclient:4.5.8'
+    compile 'org.apache.httpcomponents:httpmime:4.5.8'
+}

--- a/src/integrationTest/groovy/wooga/gradle/hockey/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/hockey/IntegrationSpec.groovy
@@ -16,7 +16,20 @@
 
 package wooga.gradle.hockey
 
+import groovy.json.StringEscapeUtils
+import nebula.test.functional.ExecutionResult
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+
 class IntegrationSpec extends nebula.test.IntegrationSpec{
+
+    @Rule
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
     def escapedPath(String path) {
         String osName = System.getProperty("os.name").toLowerCase()
@@ -32,5 +45,9 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             this.gradleVersion = gradleVersion
             fork = true
         }
+    }
+
+    Boolean outputContains(ExecutionResult result, String message) {
+        result.standardOutput.contains(message) || result.standardError.contains(message)
     }
 }

--- a/src/main/groovy/wooga/gradle/hockey/api/AppVersion.groovy
+++ b/src/main/groovy/wooga/gradle/hockey/api/AppVersion.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.hockey.api
+
+interface AppVersion {
+    String getId()
+    String getTitle()
+    String getAppId()
+
+    int getAppSize()
+    int getTimespamp()
+    String getDeviceFamily()
+    String getNotes()
+    String getVersion()
+    String getShortVersion()
+    int getStatus()
+    String getConfigUrl()
+    String getPublicUrl()
+    String getBuildUrl()
+}

--- a/src/main/groovy/wooga/gradle/hockey/api/internal/DefaultAppVersion.groovy
+++ b/src/main/groovy/wooga/gradle/hockey/api/internal/DefaultAppVersion.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.hockey.api.internal
+
+import groovy.json.JsonSlurper
+import wooga.gradle.hockey.api.AppVersion
+
+/**
+ * "title": "HockeyTest",
+ * "appsize": 1598428,
+ * "timestamp": 1308930206,
+ * "device_family": "iPhone/iPod",
+ * "minimum_os_version": "4.0",
+ * "notes": "<p>Some new features and fixed bugs.</p>",
+ * "version": "8",
+ * "shortversion": "1.0",
+ * "status": 2,
+ * "config_url": "https://rink.hockeyapp.net/manage/apps/123/app_versions/8",
+ * "public_url": "https://rink.hockeyapp.net/apps/1234567890abcdef1234567890abcdef"
+ */
+class DefaultAppVersion implements AppVersion{
+    String id
+    String title
+    String appId
+
+    int appSize
+    int timespamp
+    String deviceFamily
+    String notes
+    String version
+    String shortVersion
+    int status
+    String configUrl
+    String publicUrl
+    String buildUrl
+
+    protected DefaultAppVersion() {}
+
+    DefaultAppVersion(File file) {
+        this(file.newInputStream())
+    }
+
+    DefaultAppVersion(InputStream inputStream) {
+        this(new JsonSlurper().parse(inputStream))
+    }
+
+    protected DefaultAppVersion(Object json) {
+        id = json["id"] as String
+        title = json["title"] as String
+        appId = json["app_id"] as String
+        appSize = json["appsize"] as int
+        timespamp = json["timestamp"] as int
+        deviceFamily = json["device_family"] as String
+        notes = json["notes"] as String
+        version = json["version"] as String
+        shortVersion = json["shortversion"] as String
+        status = json["status"] as int
+        configUrl = json["config_url"] as String
+        publicUrl = json["public_url"] as String
+        buildUrl = json["build_url"] as String
+    }
+}


### PR DESCRIPTION
## Description

This patch improves the `HockeyUploadTask` in two ways.

* switch to `apache:httpclient` for upload
* save upload result metadata `HockeyAppVersion`

I moved from using curl to `httpclient`. The setup is very simple if a little bit verbose. But it supports everything we need to `POST` a multipart payload. The main reason why I wanted to switch is to read the response body of the request. Hockey returns a JSON body with information about the created app version

**example from [support.hockeyapp.net][api-versions]
```json
{
    "title": "HockeyTest",
    "appsize": 1598428,
    "timestamp": 1308930206,
    "device_family": "iPhone/iPod",
    "minimum_os_version": "4.0",
    "notes": "<p>Some new features and fixed bugs.</p>",
    "version": "8",
    "shortversion": "1.0",
    "status": 2,
    "config_url": "https://rink.hockeyapp.net/manage/apps/123/app_versions/8",
    "public_url": "https://rink.hockeyapp.net/apps/1234567890abcdef1234567890abcdef"
}
```

> The actual body contains more fields.

The `HockeyUploadTask` will save this result as an `Outputfile` and also parse it into a simple model `HockeyAppVersion`. This allows other tasks to access this information.

## Changes

![ADD] new compile dependency `org.apache.httpcomponents:httpclient`
![ADD] new compile dependency `org.apache.httpcomponents:httpmime`
![IMPROVE] switch upload logic from `curl` to `httpclient`
![IMPROVE] save upload result body in file
![IMPROVE] provide runtime model for upload result

[api-versions]:    https://support.hockeyapp.net/kb/api/api-versions#upload-version

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
