### PR TITLE
Fix publishAppCenter lifecycle hooks

### DIFF
--- a/src/main/groovy/wooga/gradle/hockey/HockeyPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/hockey/HockeyPlugin.groovy
@@ -54,6 +54,6 @@ class HockeyPlugin implements Plugin<Project> {
         })
 
         def lifecyclePublishTask = tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
-        lifecyclePublishTask.dependsOn(publishHockey, publishHockey)
+        lifecyclePublishTask.dependsOn(publishAppCenter, publishHockey)
     }
 }

--- a/src/test/groovy/wooga/gradle/hockey/HockeyPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/hockey/HockeyPluginSpec.groovy
@@ -19,12 +19,12 @@ package wooga.gradle.hockey
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
 import org.gradle.api.publish.plugins.PublishingPlugin
+import wooga.gradle.hockey.tasks.AppCenterUploadTask
 import wooga.gradle.hockey.tasks.HockeyUploadTask
 import spock.lang.Unroll
 
 class HockeyPluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.hockey'
-    public static final String TASK_NAME = 'publishHockey'
 
     def 'applies plugin'() {
         given:
@@ -55,12 +55,14 @@ class HockeyPluginSpec extends ProjectSpec {
         taskType.isInstance(task)
 
         where:
-        taskName                                         | taskType
-        PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME     | DefaultTask
-        TASK_NAME                                        | HockeyUploadTask
+        taskName                                     | taskType
+        PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME | DefaultTask
+        "publishHockey"                              | HockeyUploadTask
+        "publishAppCenter"                           | AppCenterUploadTask
     }
 
-    def 'publish task depends on publishHockey'() {
+    @Unroll
+    def 'publish task depends on #taskName'() {
         given:
         assert !project.plugins.hasPlugin(PLUGIN_NAME)
 
@@ -73,7 +75,12 @@ class HockeyPluginSpec extends ProjectSpec {
 
         then:
         project.evaluate()
-        def publishHockey = project.tasks.findByName(TASK_NAME)
+        def publishHockey = project.tasks.findByName(taskName)
         publishTask.getDependsOn().contains(publishHockey)
+
+        where:
+        taskName           | _
+        "publishHockey"    | _
+        "publishAppCenter" | _
     }
 }


### PR DESCRIPTION
## Description

I made an error and provided the `publishHockey` task twice as a dependency for `publish`. This patch fixes this and also adjusts the tests to check for these kind of issues.

## Changes

![FIX] `publishAppCenter` lifecycle hooks

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
