### PR TITLE
Add releaseNotes support to AppCenterUploadTask

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -127,6 +127,23 @@ class AppCenterUploadTask extends ConventionTask {
         this
     }
 
+    private Object releaseNotes
+
+    @Optional
+    @Input
+    String getReleaseNotes() {
+        convertToString(releaseNotes)
+    }
+
+    void setReleaseNotes(Object value) {
+        releaseNotes = value
+    }
+
+    AppCenterUploadTask releaseNotes(Object releaseNotes) {
+        setReleaseNotes(releaseNotes)
+        this
+    }
+
     private List<Map<String,String>> destinations = new ArrayList<>()
 
     @Input
@@ -267,7 +284,7 @@ class AppCenterUploadTask extends ConventionTask {
         jsonSlurper.parseText(response.entity.content.text) as Map
     }
 
-    private static void distribute(HttpClient client, String owner, String applicationIdentifier, String apiToken, String releaseId, List<Map<String,String>> destinations, AppCenterBuildInfo buildInfo) {
+    private static void distribute(HttpClient client, String owner, String applicationIdentifier, String apiToken, String releaseId, List<Map<String,String>> destinations, AppCenterBuildInfo buildInfo, String releaseNotes) {
         //     curl -X PATCH --header 'Content-Type: application/json'
         //                   --header 'Accept: application/json'
         //                   --header 'X-API-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -295,7 +312,8 @@ class AppCenterUploadTask extends ConventionTask {
             build["commit_message"] = buildInfo.commitMessage
         }
 
-        def body = ["destinations": destinations, "build": build]
+        def body = ["destinations": destinations, "build": build, "release_notes": releaseNotes]
+
         patch.setEntity(new StringEntity(JsonOutput.toJson(body), ContentType.APPLICATION_JSON))
 
         HttpResponse response = client.execute(patch)
@@ -319,7 +337,7 @@ class AppCenterUploadTask extends ConventionTask {
         String releaseId = resource["release_id"].toString()
         String releaseUrl = resource["release_url"].toString()
 
-        distribute(client, getOwner(), getApplicationIdentifier(), getApiToken(), releaseId, getDestinations(), getBuildInfo())
+        distribute(client, getOwner(), getApplicationIdentifier(), getApiToken(), releaseId, getDestinations(), getBuildInfo(), getReleaseNotes() ?: "")
 
         logger.info("published to AppCenter release: ${releaseId}")
         logger.info("release_url: ${releaseUrl}")


### PR DESCRIPTION
## Description

As requested in issue [wooga/atlas-appcenter#13], this patch adds support to pass custom release notes to the AppCenter distribution.

_example_

```groovy

publishAppCenter {
    owner = "some_org"
    apiToken = "A_KEY"
    applicationIdentifier = "MYAPP"
    binary = "path/to/file"

    releaseNotes = """
    This is a new awesome release with lots of cool content
    Things you need to check out

    * awesome feature here
    * crazy new function over here
    """.stripIndent().trim()
}
```

resolves #13 

## Changes

* ![ADD] release note support to `AppCenterUploadTask`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
