### PR TITLE
Switch to Provider API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,33 @@ Gradle and Java Compatibility
 Built with Oracle JDK7
 Tested with Oracle JDK8
 
-| Gradle Version  | Works  |
-| :-------------: | :----: |
-| 4.0             | ![yes] |
-| 4.1             | ![yes] |
-| 4.2             | ![yes] |
-| 4.3             | ![yes] |
-| 4.4             | ![yes] |
-| 4.5             | ![yes] |
-| 4.6             | ![yes] |
-| 4.6             | ![yes] |
-| 4.7             | ![yes] |
-| 4.8             | ![yes] |
-| 4.9             | ![yes] |
-| 4.10            | ![yes] |
+| Gradle Version  | Works    |
+| :-------------: | :------: |
+| 4.0             | `v0.6.0` |
+| 4.1             | `v0.6.0` |
+| 4.2             | `v0.6.0` |
+| 4.3             | `v0.6.0` |
+| 4.4             | ![yes]   |
+| 4.5             | ![yes]   |
+| 4.6             | ![yes]   |
+| 4.6             | ![yes]   |
+| 4.7             | ![yes]   |
+| 4.8             | ![yes]   |
+| 4.9             | ![yes]   |
+| 4.10.2          | ![yes]   |
+| 5.0             | ![yes]   |
+| 5.1             | ![yes]   |
+| 5.2             | ![yes]   |
+| 5.3             | ![yes]   |
+| 5.4             | ![yes]   |
+| 5.5             | ![yes]   |
+| 5.6.4           | ![yes]   |
+| 6.0             | ![yes]   |
+| 6.1             | ![yes]   |
+| 6.2             | ![yes]   |
+| 6.3             | ![yes]   |
+| 6.4             | ![yes]   |
+ 
 
 LICENSE
 =======

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,6 +16,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 
-versions=("4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10")
+versions=("4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10" "5.0" "5.1" "5.2" "5.3" "5.4" "5.5" "5.6.4" "6.0" "6.1" "6.2" "6.3" "6.4")
 
+rm -fr build/reports
 for i in "${versions[@]}"
 do
     echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew test &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/test "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+
     GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
     status=$?
     mkdir -p "build/reports/$i"
     mv build/reports/integrationTest "build/reports/$i"
     if [ $status -ne 0 ]; then
-        echo "test error $i"
+        echo "integrationTest error $i"
     fi
 done

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -41,8 +41,7 @@ class AppCenterPlugin implements Plugin<Project> {
             @Override
             void execute(AppCenterUploadTask t) {
                 t.buildVersion.set(project.providers.provider({ project.version.toString() }))
-                t.destinations.set([])
-                t.defaultDestinations.set([["name": "Collaborators"]])
+                t.destinations.set([["name": "Collaborators"]])
             }
         })
 

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -40,9 +40,9 @@ class AppCenterPlugin implements Plugin<Project> {
         tasks.withType(AppCenterUploadTask, new Action<AppCenterUploadTask>() {
             @Override
             void execute(AppCenterUploadTask t) {
-                def conventionMapping = t.getConventionMapping()
-                conventionMapping.map("buildVersion", {project.version})
-                conventionMapping.map("destinations", {[["name": "Collaborators"]]})
+                t.buildVersion.set(project.providers.provider({ project.version.toString() }))
+                t.destinations.set([])
+                t.defaultDestinations.set([["name": "Collaborators"]])
             }
         })
 

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -101,9 +101,9 @@ class AppCenterUploadTask extends DefaultTask {
     @Input
     final ListProperty<Map<String, String>> destinations
 
-    @Optional
-    @Internal
-    final ListProperty<Map<String, String>> defaultDestinations
+    void setDestinations(Iterable<String> value) {
+        destinations.set(value.collect {["name": it]})
+    }
 
     void destination(String name) {
         destinations.add(["name": name])
@@ -170,7 +170,6 @@ class AppCenterUploadTask extends DefaultTask {
         applicationIdentifier = project.objects.property(String)
         releaseNotes = project.objects.property(String)
         destinations = project.objects.listProperty(Map)
-        defaultDestinations = project.objects.listProperty(Map)
 
         binary = projectLayout.fileProperty()
         outputDir = projectLayout.directoryProperty()
@@ -292,9 +291,7 @@ class AppCenterUploadTask extends DefaultTask {
         Integer releaseId = releaseId.getOrElse(0)
         File binary = binary.get().asFile
         List<Map<String, String>> destinations = destinations.getOrElse([])
-        if(destinations.empty) {
-            destinations = defaultDestinations.get()
-        }
+
         String releaseNotes = releaseNotes.getOrElse("")
 
         def uploadResource = createUploadResource(client, owner, applicationIdentifier, apiToken, buildVersion, releaseId)

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -1,20 +1,3 @@
-/*
- * Copyright 2019 Wooga GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package wooga.gradle.appcenter.tasks
 
 import groovy.json.JsonOutput
@@ -30,126 +13,97 @@ import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.apache.http.entity.mime.content.FileBody
 import org.apache.http.impl.client.HttpClientBuilder
 import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.ConventionTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
-import org.gradle.internal.impldep.com.google.gson.JsonObject
 import wooga.gradle.appcenter.api.AppCenterBuildInfo
+import wooga.gradle.compat.ProjectLayout
+
 import static org.gradle.util.ConfigureUtil.configureUsing
 
-import java.util.concurrent.Callable
-
-class AppCenterUploadTask extends ConventionTask {
-
-    private Object apiToken
+class AppCenterUploadTask extends DefaultTask {
 
     @Input
-    String getApiToken() {
-        convertToString(apiToken)
+    final Property<String> apiToken
+
+    void setApiToken(String value) {
+        apiToken.set(value)
     }
 
-    void setApiToken(Object value) {
-        apiToken = value
+    void apiToken(String value) {
+        setApiToken(value)
     }
-
-    AppCenterUploadTask apiToken(Object apiToken) {
-        setApiToken(apiToken)
-        this
-    }
-
-    private Object owner
 
     @Input
-    String getOwner() {
-        convertToString(owner)
+    final Property<String> owner
+
+    void setOwner(String value) {
+        owner.set(value)
     }
 
-    void setOwner(Object value) {
-        owner = value
+    void owner(String value) {
+        setOwner(value)
     }
-
-    AppCenterUploadTask owner(Object owner) {
-        setOwner(owner)
-        this
-    }
-
-    private Object buildVersion
 
     @Input
-    String getBuildVersion() {
-        convertToString(buildVersion)
+    final Property<String> buildVersion
+
+    void setBuildVersion(String value) {
+        buildVersion.set(value)
     }
 
-    void setBuildVersion(Object value) {
-        buildVersion = value
+    void buildVersion(String value) {
+        setBuildVersion(value)
     }
-
-    AppCenterUploadTask buildVersion(Object buildVersion) {
-        setBuildVersion(buildVersion)
-        this
-    }
-
-    private Object releaseId
 
     @Optional
     @Input
-    int getReleaseId() {
-        if (!releaseId) {
-            return 0
-        }
+    final Property<Integer> releaseId
 
-        Integer.parseInt(convertToString(releaseId))
+    void setReleaseId(Integer value) {
+        releaseId.set(value)
     }
 
-    void setReleaseId(Object value) {
-        releaseId = value
+    void releaseId(Integer value) {
+        setReleaseId(value)
     }
-
-    AppCenterUploadTask releaseId(Object releaseId) {
-        setReleaseId(releaseId)
-        this
-    }
-
-    private Object applicationIdentifier
 
     @Input
-    String getApplicationIdentifier() {
-        convertToString(applicationIdentifier)
+    final Property<String> applicationIdentifier
+
+    void setApplicationIdentifier(String value) {
+        applicationIdentifier.set(value)
     }
 
-    void setApplicationIdentifier(Object value) {
-        applicationIdentifier = value
+    void applicationIdentifier(String value) {
+        setApplicationIdentifier(value)
     }
-
-    AppCenterUploadTask applicationIdentifier(Object applicationIdentifier) {
-        setApplicationIdentifier(applicationIdentifier)
-        this
-    }
-
-    private Object releaseNotes
 
     @Optional
     @Input
-    String getReleaseNotes() {
-        convertToString(releaseNotes)
+    final Property<String> releaseNotes
+
+    void setReleaseNotes(String value) {
+        releaseNotes.set(value)
     }
 
-    void setReleaseNotes(Object value) {
-        releaseNotes = value
+    void releaseNotes(String value) {
+        setReleaseNotes(value)
     }
 
-    AppCenterUploadTask releaseNotes(Object releaseNotes) {
-        setReleaseNotes(releaseNotes)
-        this
-    }
-
-    private List<Map<String,String>> destinations = new ArrayList<>()
-
+    @Optional
     @Input
-    protected List<Map<String,String>> getDestinations() {
-        destinations
-    }
+    final ListProperty<Map<String, String>> destinations
+
+    @Optional
+    @Internal
+    final ListProperty<Map<String, String>> defaultDestinations
 
     void destination(String name) {
         destinations.add(["name": name])
@@ -182,42 +136,47 @@ class AppCenterUploadTask extends ConventionTask {
         action.execute(buildInfo)
     }
 
-    private Object binary
+    @InputFile
+    final RegularFileProperty binary
 
-    @SkipWhenEmpty
-    @InputFiles
-    protected FileCollection getInputFiles() {
-        if (!binary) {
-            return project.files()
-        }
-        return project.files(binary)
+    void setBinary(String value) {
+        binary.set(project.file(value))
     }
 
-    File getBinary() {
-
-        def files = getInputFiles()
-        if (files.size() > 0) {
-            return files.getSingleFile()
-        }
-        return null
+    void setBinary(File value) {
+        binary.set(value)
     }
 
-    void setBinary(Object value) {
-        binary = value
+    void binary(String value) {
+        setBinary(value)
     }
 
-    AppCenterUploadTask binary(Object binary) {
-        setBinary(binary)
-        this
+    void binary(File value) {
+        setBinary(value)
     }
 
-    @OutputFiles
-    protected FileCollection getOutputFiles() {
-        return project.files(getUploadVersionMetaData())
-    }
+    @Internal
+    protected final DirectoryProperty outputDir
 
-    File getUploadVersionMetaData() {
-        new File(temporaryDir, "${getOwner()}_${getApplicationIdentifier()}.json")
+    @OutputFile
+    final Provider<RegularFile> uploadVersionMetaData
+
+    AppCenterUploadTask() {
+        def projectLayout = new ProjectLayout(project)
+        apiToken = project.objects.property(String)
+        owner = project.objects.property(String)
+        buildVersion = project.objects.property(String)
+        releaseId = project.objects.property(Integer)
+        applicationIdentifier = project.objects.property(String)
+        releaseNotes = project.objects.property(String)
+        destinations = project.objects.listProperty(Map)
+        defaultDestinations = project.objects.listProperty(Map)
+
+        binary = projectLayout.fileProperty()
+        outputDir = projectLayout.directoryProperty()
+        outputDir.set(temporaryDir)
+
+        uploadVersionMetaData = outputDir.file(owner.map({ owner -> "${owner}_${applicationIdentifier.get()}.json" }))
     }
 
     private static Map createUploadResource(HttpClient client, String owner, String applicationIdentifier, String apiToken, String buildVersion, int releaseId = 0) {
@@ -284,7 +243,7 @@ class AppCenterUploadTask extends ConventionTask {
         jsonSlurper.parseText(response.entity.content.text) as Map
     }
 
-    private static void distribute(HttpClient client, String owner, String applicationIdentifier, String apiToken, String releaseId, List<Map<String,String>> destinations, AppCenterBuildInfo buildInfo, String releaseNotes) {
+    private static void distribute(HttpClient client, String owner, String applicationIdentifier, String apiToken, String releaseId, List<Map<String, String>> destinations, AppCenterBuildInfo buildInfo, String releaseNotes) {
         //     curl -X PATCH --header 'Content-Type: application/json'
         //                   --header 'Accept: application/json'
         //                   --header 'X-API-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
@@ -300,15 +259,15 @@ class AppCenterUploadTask extends ConventionTask {
 
         def build = [:]
 
-        if(buildInfo.branchName && !buildInfo.branchName.empty) {
+        if (buildInfo.branchName && !buildInfo.branchName.empty) {
             build["branch_name"] = buildInfo.branchName
         }
 
-        if(buildInfo.commitHash && !buildInfo.commitHash.empty) {
+        if (buildInfo.commitHash && !buildInfo.commitHash.empty) {
             build["commit_hash"] = buildInfo.commitHash
         }
 
-        if(buildInfo.commitMessage && !buildInfo.commitMessage.empty) {
+        if (buildInfo.commitMessage && !buildInfo.commitMessage.empty) {
             build["commit_message"] = buildInfo.commitMessage
         }
 
@@ -326,34 +285,35 @@ class AppCenterUploadTask extends ConventionTask {
     @TaskAction
     protected void upload() {
         HttpClient client = HttpClientBuilder.create().build()
-        def uploadResource = createUploadResource(client, getOwner(), getApplicationIdentifier(), getApiToken(), getBuildVersion(), getReleaseId())
+        String owner = owner.get()
+        String applicationIdentifier = applicationIdentifier.get()
+        String apiToken = apiToken.get()
+        String buildVersion = buildVersion.get()
+        Integer releaseId = releaseId.getOrElse(0)
+        File binary = binary.get().asFile
+        List<Map<String, String>> destinations = destinations.getOrElse([])
+        if(destinations.empty) {
+            destinations = defaultDestinations.get()
+        }
+        String releaseNotes = releaseNotes.getOrElse("")
+
+        def uploadResource = createUploadResource(client, owner, applicationIdentifier, apiToken, buildVersion, releaseId)
 
         String uploadUrl = uploadResource["upload_url"]
         String uploadId = uploadResource["upload_id"]
 
-        uploadResources(client, getApiToken(), uploadUrl, getBinary())
+        uploadResources(client, apiToken, uploadUrl, binary)
 
-        def resource = commitResource(client, getOwner(), getApplicationIdentifier(), getApiToken(), uploadId)
-        String releaseId = resource["release_id"].toString()
+        def resource = commitResource(client, owner, applicationIdentifier, apiToken, uploadId)
+        String finalReleaseId = resource["release_id"].toString()
         String releaseUrl = resource["release_url"].toString()
 
-        distribute(client, getOwner(), getApplicationIdentifier(), getApiToken(), releaseId, getDestinations(), getBuildInfo(), getReleaseNotes() ?: "")
+        distribute(client, owner, applicationIdentifier, apiToken, finalReleaseId, destinations, getBuildInfo(), releaseNotes)
 
-        logger.info("published to AppCenter release: ${releaseId}")
+        logger.info("published to AppCenter release: ${finalReleaseId}")
         logger.info("release_url: ${releaseUrl}")
 
-        getUploadVersionMetaData() << JsonOutput.prettyPrint(JsonOutput.toJson(resource))
+        uploadVersionMetaData.get().asFile << JsonOutput.prettyPrint(JsonOutput.toJson(resource))
     }
 
-    private static String convertToString(Object value) {
-        if (!value) {
-            return null
-        }
-
-        if (value instanceof Callable) {
-            value = ((Callable) value).call()
-        }
-
-        value.toString()
-    }
 }

--- a/src/main/groovy/wooga/gradle/compat/ProjectLayout.groovy
+++ b/src/main/groovy/wooga/gradle/compat/ProjectLayout.groovy
@@ -1,0 +1,37 @@
+package wooga.gradle.compat
+
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+
+class ProjectLayout {
+
+    final Project project
+    final String gradleVersion
+    final Object compatFactory
+
+    ProjectLayout(Project project) {
+        this.project = project
+        gradleVersion = project.gradle.gradleVersion
+        compatFactory = gradleVersion.startsWith("6.") ? project.objects : project.layout
+    }
+
+    DirectoryProperty directoryProperty() {
+        (DirectoryProperty) compatFactory.invokeMethod("directoryProperty", null)
+    }
+
+    DirectoryProperty directoryProperty(Provider<? extends Directory> var1) {
+        (DirectoryProperty) compatFactory.invokeMethod("directoryProperty", var1)
+    }
+
+    RegularFileProperty fileProperty() {
+        (RegularFileProperty) compatFactory.invokeMethod("fileProperty", null)
+    }
+
+    RegularFileProperty fileProperty(Provider<? extends RegularFile> var1) {
+        (RegularFileProperty) compatFactory.invokeMethod("fileProperty", var1)
+    }
+}


### PR DESCRIPTION
## Description

The current plugin source used the old and internal convention mapping logic. It seems it is still supported up to gradle `6.4`. But understanding and using this API is not straight forward. This patch moves to the `Provider` API introduced in gradle `4.4`. We will lose support for some earlier gradle `4.x` versions but the code becomes easier to read and maintain. I adjusted the `gradle_check_versions.sh` file to test all gradle releases up to `6.4`. All worked well except some internal defaults when it comes to work with the `Provider` API and some breaking changes with gradle `6.x`. I fixed those with a `compat` helper class and resolve the API break at runtime. Since the goal is to move to gradle `6.x` by the end of the year I see no major issue with this.

## Changes

* ![IMPROVE] switch to `Provider` API
* ![UPDATE] ![GRADLE] base version to `4.10.2`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "GRADLE"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
