### PR TITLE
Add publish enable flag in appcenter extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ appCenter {
    owner = ""
    applicationIdentifier = ""
    defaultDestinations = ["", ""]
+   publishEnabled = false
 }
 ```
 
 The properties are by default looked up in the gradle properties and/or environment.
 
 | property              | gradle property name              | environment variable                |
-| -------------------- | --------------------------------- | ----------------------------------- |
+| --------------------- | --------------------------------- | ----------------------------------- |
 | apiToken              | `appCenter.apiToken`              | `APP_CENTER_API_TOKEN`              |
 | owner                 | `appCenter.owner`                 | `APP_CENTER_OWNER`                  |
 | applicationIdentifier | `appCenter.applicationIdentifier` | `APP_CENTER_APPLICATION_IDENTIFIER` |
 | defaultDestinations   | `appCenter.defaultDestinations`   | `APP_CENTER_DEFAULT_DESTINATIONS`   |
-
+| publishEnabled        | `appCenter.publishEnabled`        | `APP_CENTER_PUBLISH_ENABLED`        |
 
 Development
 ===========

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -100,6 +100,33 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         "defaultDestinations"   | "['group3','group4']" | [["name": "group3"], ["name": "group4"]] | "[group3,group4]" | PropertyLocation.script
         "defaultDestinations"   | null                  | [["name": "Collaborators"]]              | "null"            | PropertyLocation.none
 
+        "publishEnabled"        | true                  | _                                        | true              | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 1                 | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | "TRUE"            | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 'y'               | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 'yes'             | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 'YES'             | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | false             | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 0                 | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | "FALSE"           | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 'n'               | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 'no'              | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | 'NO'              | PropertyLocation.env
+        "publishEnabled"        | true                  | _                                        | true              | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 1                 | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | "TRUE"            | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 'y'               | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 'yes'             | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 'YES'             | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | false             | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 0                 | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | "FALSE"           | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 'n'               | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 'no'              | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | 'NO'              | PropertyLocation.property
+        "publishEnabled"        | true                  | _                                        | true              | PropertyLocation.script
+        "publishEnabled"        | false                 | _                                        | false             | PropertyLocation.script
+        "publishEnabled"        | true                  | _                                        | null              | PropertyLocation.none
 
         testValue = (expectedValue == _) ? value : expectedValue
         reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with '$providedValue'")
@@ -136,4 +163,40 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         "defaultDestinations" | "setDefaultDestinations" | ["group1", "group2"] | "List<String>" | [[name: "group1"], [name: "group2"]]
         value = wrapValueBasedOnType(rawValue, type)
     }
+
+    static String apiToken = System.env["ATLAS_APP_CENTER_INTEGRATION_API_TOKEN"]
+    static String owner = System.env["ATLAS_APP_CENTER_OWNER"]
+    static String applicationIdentifier = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER"]
+
+    @Unroll()
+    def "task :#taskName #message on task :#dependedTask when enabled is #enabled"() {
+        given: "a project with property set"
+        buildFile << """
+            appCenter {
+                owner = "$owner"
+                apiToken = "$apiToken"
+                applicationIdentifier = "$applicationIdentifier"
+                publishEnabled = ${enabled}
+            }
+        """
+
+        and: "a dummy ipa binary to upload"
+        def testFile = getClass().getClassLoader().getResource("test.ipa").path
+        buildFile << """
+            publishAppCenter.binary = "$testFile"
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(taskName)
+
+        then:
+        result.wasExecuted(dependedTask) == dependsOnTask
+
+        where:
+        taskName  | dependedTask       | enabled | dependsOnTask
+        "publish" | "publishAppCenter" | true    | true
+        "publish" | "publishAppCenter" | false   | false
+        message = (dependsOnTask) ? "depends" : "depends not"
+    }
+
 }

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
@@ -50,9 +50,6 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
 
     def "uploads dummy ipa to AppCenter successfully"() {
         given: "a dummy ipa binary to upload"
-
-        "true".toBoolean()
-
         def testFile = getClass().getClassLoader().getResource("test.ipa").path
         buildFile << """
             publishAppCenter.binary = "$testFile"

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
@@ -17,6 +17,8 @@
 
 package wooga.gradle.appcenter
 
+import com.sun.org.apache.xpath.internal.operations.Bool
+
 class AppCenterConsts {
     static String API_TOKEN_OPTION = "appCenter.apiToken"
     static String API_TOKEN_ENV_VAR = "APP_CENTER_API_TOKEN"
@@ -30,4 +32,8 @@ class AppCenterConsts {
     static List<Map<String, String>> defaultDestinations = [["name": "Collaborators"]]
     static String DEFAULT_DESTINATIONS_OPTION = "appCenter.defaultDestinations"
     static String DEFAULT_DESTINATIONS_ENV_VAR = "APP_CENTER_DEFAULT_DESTINATIONS"
+
+    static Boolean defaultPublishEnabled = true
+    static String PUBLISH_ENABLED_OPTION = "appCenter.publishEnabled"
+    static String PUBLISH_ENABLED_ENV_VAR = "APP_CENTER_PUBLISH_ENABLED"
 }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -52,8 +52,15 @@ class AppCenterPlugin implements Plugin<Project> {
             }
         })
 
-        def lifecyclePublishTask = tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
-        lifecyclePublishTask.dependsOn(publishAppCenter)
+        project.afterEvaluate(new Action<Project>() {
+            @Override
+            void execute(Project _) {
+                if(extension.isPublishEnabled().get()) {
+                    def lifecyclePublishTask = tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+                    lifecyclePublishTask.dependsOn(publishAppCenter)
+                }
+            }
+        })
     }
 
     protected static AppCenterPluginExtension create_and_configure_extension(Project project) {
@@ -85,6 +92,15 @@ class AppCenterPlugin implements Plugin<Project> {
                     ?: System.getenv()[AppCenterConsts.APPLICATION_IDENTIFIER_ENV_VAR]) as String
         }))
 
+        extension.publishEnabled.set(project.provider({
+            String rawValue = (project.properties[AppCenterConsts.PUBLISH_ENABLED_OPTION]
+                    ?: System.getenv()[AppCenterConsts.PUBLISH_ENABLED_ENV_VAR]) as String
+
+            if (rawValue) {
+                return (rawValue == "1" || rawValue.toLowerCase() == "yes" || rawValue.toLowerCase() == "y" || rawValue.toLowerCase() == "true")
+            }
+            AppCenterConsts.defaultPublishEnabled
+        }))
         extension
     }
 }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
@@ -40,4 +40,8 @@ interface AppCenterPluginExtension {
     void defaultDestination(Iterable<String> destinations)
     void defaultDestination(String... destinations)
     void defaultDestinationId(String id)
+
+    Property<Boolean> getPublishEnabled()
+    Property<Boolean> isPublishEnabled()
+    void setPublishEnabled(final boolean enabled)
 }

--- a/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
@@ -10,12 +10,14 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
     final Property<String> owner
     final Property<String> applicationIdentifier
     final ListProperty<Map<String, String>> defaultDestinations
+    final Property<Boolean> publishEnabled
 
     DefaultAppCenterPluginExtension(Project project) {
         apiToken = project.objects.property(String)
         owner = project.objects.property(String)
         applicationIdentifier = project.objects.property(String)
         defaultDestinations = project.objects.listProperty(Map)
+        publishEnabled = project.objects.property(Boolean)
     }
 
     @Override
@@ -71,5 +73,15 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
     @Override
     void defaultDestinationId(String id) {
         defaultDestinations.add(["id": id])
+    }
+
+    @Override
+    Property<Boolean> isPublishEnabled() {
+        return publishEnabled
+    }
+
+    @Override
+    void setPublishEnabled(boolean enabled) {
+        this.publishEnabled.set(enabled)
     }
 }


### PR DESCRIPTION
## Description

This patch adds a new property `publishEnabled` to the appcenter extensions. This property controls if the `publishAppCenter` task created by the plugin is added as a dependency of the `publish` task.

The task can still be called indipendently. Other tasks of type `AppCenterUploadTask` are not by default added to the `publish` lifecycle task.

## Changes

* ![ADD] `publishEnable` property

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
