### PR TITLE
Fix missing multiple value setter

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -74,59 +74,60 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("appCenter.${property}: ${testValue}")
 
         where:
-        property                | value                 | expectedValue                            | providedValue     | location
-        "apiToken"              | "xxx"                 | _                                        | "xxx"             | PropertyLocation.env
-        "apiToken"              | "yyy"                 | _                                        | "yyy"             | PropertyLocation.property
-        "apiToken"              | "'zzz'"               | "zzz"                                    | "zzz"             | PropertyLocation.script
-        "apiToken"              | null                  | _                                        | "null"            | PropertyLocation.none
+        property                | value                        | expectedValue                            | providedValue     | location
+        "apiToken"              | "xxx"                        | _                                        | "xxx"             | PropertyLocation.env
+        "apiToken"              | "yyy"                        | _                                        | "yyy"             | PropertyLocation.property
+        "apiToken"              | "'zzz'"                      | "zzz"                                    | "zzz"             | PropertyLocation.script
+        "apiToken"              | null                         | _                                        | "null"            | PropertyLocation.none
 
-        "owner"                 | "xxx"                 | _                                        | "xxx"             | PropertyLocation.env
-        "owner"                 | "yyy"                 | _                                        | "yyy"             | PropertyLocation.property
-        "owner"                 | "'zzz'"               | "zzz"                                    | "zzz"             | PropertyLocation.script
-        "owner"                 | null                  | _                                        | "null"            | PropertyLocation.none
+        "owner"                 | "xxx"                        | _                                        | "xxx"             | PropertyLocation.env
+        "owner"                 | "yyy"                        | _                                        | "yyy"             | PropertyLocation.property
+        "owner"                 | "'zzz'"                      | "zzz"                                    | "zzz"             | PropertyLocation.script
+        "owner"                 | null                         | _                                        | "null"            | PropertyLocation.none
 
-        "applicationIdentifier" | "xxx"                 | _                                        | "xxx"             | PropertyLocation.env
-        "applicationIdentifier" | "yyy"                 | _                                        | "yyy"             | PropertyLocation.property
-        "applicationIdentifier" | "'zzz'"               | "zzz"                                    | "zzz"             | PropertyLocation.script
-        "applicationIdentifier" | null                  | _                                        | "null"            | PropertyLocation.none
+        "applicationIdentifier" | "xxx"                        | _                                        | "xxx"             | PropertyLocation.env
+        "applicationIdentifier" | "yyy"                        | _                                        | "yyy"             | PropertyLocation.property
+        "applicationIdentifier" | "'zzz'"                      | "zzz"                                    | "zzz"             | PropertyLocation.script
+        "applicationIdentifier" | null                         | _                                        | "null"            | PropertyLocation.none
 
-        "defaultDestinations"   | "group1"              | [["name": "group1"]]                     | "group1"          | PropertyLocation.env
-        "defaultDestinations"   | "group1,group2"       | [["name": "group1"], ["name": "group2"]] | "group1,group2"   | PropertyLocation.env
-        "defaultDestinations"   | "group1, group2"      | [["name": "group1"], ["name": "group2"]] | "group1, group2"  | PropertyLocation.env
-        "defaultDestinations"   | "group2"              | [["name": "group2"]]                     | "group2"          | PropertyLocation.property
-        "defaultDestinations"   | "group2,group3"       | [["name": "group2"], ["name": "group3"]] | "group2,group3"   | PropertyLocation.property
-        "defaultDestinations"   | "group2, group3"      | [["name": "group2"], ["name": "group3"]] | "group2, group3"  | PropertyLocation.property
-        "defaultDestinations"   | "['group3']"          | [["name": "group3"]]                     | "[group3]"        | PropertyLocation.script
-        "defaultDestinations"   | "['group3','group4']" | [["name": "group3"], ["name": "group4"]] | "[group3,group4]" | PropertyLocation.script
-        "defaultDestinations"   | null                  | [["name": "Collaborators"]]              | "null"            | PropertyLocation.none
+        "defaultDestinations"   | "group1"                     | [["name": "group1"]]                     | "group1"          | PropertyLocation.env
+        "defaultDestinations"   | "group1,group2"              | [["name": "group1"], ["name": "group2"]] | "group1,group2"   | PropertyLocation.env
+        "defaultDestinations"   | "group1, group2"             | [["name": "group1"], ["name": "group2"]] | "group1, group2"  | PropertyLocation.env
+        "defaultDestinations"   | "group2"                     | [["name": "group2"]]                     | "group2"          | PropertyLocation.property
+        "defaultDestinations"   | "group2,group3"              | [["name": "group2"], ["name": "group3"]] | "group2,group3"   | PropertyLocation.property
+        "defaultDestinations"   | "group2, group3"             | [["name": "group2"], ["name": "group3"]] | "group2, group3"  | PropertyLocation.property
+        "defaultDestinations"   | "['group3']"                 | [["name": "group3"]]                     | "[group3]"        | PropertyLocation.script
+        "defaultDestinations"   | "['group3','group4']"        | [["name": "group3"], ["name": "group4"]] | "[group3,group4]" | PropertyLocation.script
+        "defaultDestinations"   | "'group3,group4'.split(',')" | [["name": "group3"], ["name": "group4"]] | "String..."       | PropertyLocation.script
+        "defaultDestinations"   | null                         | [["name": "Collaborators"]]              | "null"            | PropertyLocation.none
 
-        "publishEnabled"        | true                  | _                                        | true              | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 1                 | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | "TRUE"            | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 'y'               | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 'yes'             | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 'YES'             | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | false             | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 0                 | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | "FALSE"           | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 'n'               | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 'no'              | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | 'NO'              | PropertyLocation.env
-        "publishEnabled"        | true                  | _                                        | true              | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 1                 | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | "TRUE"            | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 'y'               | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 'yes'             | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 'YES'             | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | false             | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 0                 | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | "FALSE"           | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 'n'               | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 'no'              | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | 'NO'              | PropertyLocation.property
-        "publishEnabled"        | true                  | _                                        | true              | PropertyLocation.script
-        "publishEnabled"        | false                 | _                                        | false             | PropertyLocation.script
-        "publishEnabled"        | true                  | _                                        | null              | PropertyLocation.none
+        "publishEnabled"        | true                         | _                                        | true              | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 1                 | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | "TRUE"            | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 'y'               | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 'yes'             | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 'YES'             | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | false             | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 0                 | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | "FALSE"           | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 'n'               | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 'no'              | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | 'NO'              | PropertyLocation.env
+        "publishEnabled"        | true                         | _                                        | true              | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 1                 | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | "TRUE"            | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 'y'               | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 'yes'             | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 'YES'             | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | false             | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 0                 | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | "FALSE"           | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 'n'               | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 'no'              | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | 'NO'              | PropertyLocation.property
+        "publishEnabled"        | true                         | _                                        | true              | PropertyLocation.script
+        "publishEnabled"        | false                        | _                                        | false             | PropertyLocation.script
+        "publishEnabled"        | true                         | _                                        | null              | PropertyLocation.none
 
         testValue = (expectedValue == _) ? value : expectedValue
         reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with '$providedValue'")

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/IntegrationSpec.groovy
@@ -68,6 +68,9 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             case "String":
                 value = "$rawValueEscaped"
                 break
+            case "String[]":
+                value = "'{${rawValue.collect { '"' + it + '"' }.join(",")}}'.split(',')"
+                break
             case "File":
                 value = "new File('${escapedPath(rawValue.toString())}')"
                 break

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
@@ -280,8 +280,8 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         "destinations" | "destination"     | "Test1"            | "String"       | ["Collaborators", "Test1"]
         "destinations" | "destination"     | ["Test1", "Test2"] | "List<String>" | ["Collaborators", "Test1", "Test2"]
         "destinations" | "destination"     | ["Test1", "Test2"] | "String..."    | ["Collaborators", "Test1", "Test2"]
-        //"destinations" | "destinationId"   | "groupId"            | "String"       | [[name: "Collaborators"], [id: "groupId"]]
         "destinations" | "setDestinations" | ["Test1", "Test2"] | "List<String>" | ["Test1", "Test2"]
+        "destinations" | "setDestinations" | ["Test1", "Test2"] | "String..."    | ["Test1", "Test2"]
         value = wrapValueBasedOnType(rawValue, type)
     }
 

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
@@ -36,6 +36,7 @@ interface AppCenterPluginExtension {
     ListProperty<Map<String, String>> getDefaultDestinations()
 
     void setDefaultDestinations(Iterable<String> value)
+    void setDefaultDestinations(String... destinations)
     void defaultDestination(String name)
     void defaultDestination(Iterable<String> destinations)
     void defaultDestination(String... destinations)

--- a/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
@@ -56,6 +56,11 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
     }
 
     @Override
+    void setDefaultDestinations(String... destinations) {
+        defaultDestinations.set(destinations.collect {["name": it]})
+    }
+
+    @Override
     void defaultDestination(String name) {
         defaultDestinations.add(["name": name])
     }

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -105,6 +105,10 @@ class AppCenterUploadTask extends DefaultTask {
         destinations.set(value.collect {["name": it]})
     }
 
+    void setDestinations(String... value) {
+        destinations.set(value.collect {["name": it]})
+    }
+
     void destination(String name) {
         destinations.add(["name": name])
     }


### PR DESCRIPTION
## Description

This patch brings back the setter which allowed to set distribution groups with `String[]` values. One native method returns these if you call `split()` on a `String`. One could easily call `toList` on the resulting array but this plugin had the functionality before and it was forgotten when moving to the Provider API.

## Changes

* ![FIX] missing multiple value setter

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
