### PR TITLE
Improve run platform tests on different appCenter app ids

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,15 +2,32 @@
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([string(credentialsId: 'atlas_appcenter_integration_token', variable: 'appcenterToken'),
-                 string(credentialsId: 'atlas_appcenter_integration_application_identifier', variable: 'appcenterAppId'),
+                 string(credentialsId: 'atlas_appcenter_integration_application_identifier_1', variable: 'appcenterAppIdOSX'),
+                 string(credentialsId: 'atlas_appcenter_integration_application_identifier_2', variable: 'appcenterAppIdWin'),
+                 string(credentialsId: 'atlas_appcenter_integration_application_identifier_3', variable: 'appcenterAppIdLinux'),
                  string(credentialsId: 'atlas_appcenter_integration_application_owner', variable: 'appcenterOwner'),
                  string(credentialsId: 'atlas_appcenter_coveralls_token', variable: 'coveralls_token')
                  ]) {
 
     def testEnvironment = [
-                            "ATLAS_APP_CENTER_INTEGRATION_API_TOKEN=${appcenterToken}",
-                            "ATLAS_APP_CENTER_OWNER=${appcenterOwner}",
-                            "ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER=${appcenterAppId}"
+                            'osx':
+                                [
+                                        "ATLAS_APP_CENTER_INTEGRATION_API_TOKEN=${appcenterToken}",
+                                        "ATLAS_APP_CENTER_OWNER=${appcenterOwner}",
+                                        "ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER=${appcenterAppIdOSX}"
+                                ],
+                            'windows':
+                                [
+                                        "ATLAS_APP_CENTER_INTEGRATION_API_TOKEN=${appcenterToken}",
+                                        "ATLAS_APP_CENTER_OWNER=${appcenterOwner}",
+                                        "ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER=${appcenterAppIdWin}"
+                                ],
+                            'linux':
+                                [
+                                        "ATLAS_APP_CENTER_INTEGRATION_API_TOKEN=${appcenterToken}",
+                                        "ATLAS_APP_CENTER_OWNER=${appcenterOwner}",
+                                        "ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER=${appcenterAppIdLinux}"
+                                ],
                           ]
 
     buildGradlePlugin plaforms: ['osx', 'windows', 'linux'], coverallsToken: coveralls_token, testEnvironment: testEnvironment


### PR DESCRIPTION
## Description

It looks like we produce a lot of test races when parallel testing `osx`,`windows` and `linux`. This patch just pulls in three different app id values for the tests. I hope we can limit the number of `500` errors from appCenter with this.

## Changes

* ![IMPROVE] run platform test on different appCenter app ids

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
