### PR TITLE
Improve test coverage

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -133,6 +133,53 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with '$providedValue'")
     }
 
+    @Unroll
+    def "can set property :#property with :#method and type '#type'"() {
+        given: "a task to print appCenter properties"
+        buildFile << """
+            task(custom) {
+                doLast {
+                    def value = appCenter.${property}.get()
+                    println("appCenter.${property}: " + value)
+                }
+            }
+        """
+
+        and: "some configured property"
+        buildFile << "appCenter.${method}(${value})"
+
+        and: "the test value with replace placeholders"
+        if (value instanceof String) {
+            value = value.replaceAll("#projectDir#", escapedPath(projectDir.path))
+        }
+
+        when: ""
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("appCenter.${property}: ${rawValue}")
+
+        where:
+        property                | method                      | rawValue                 | type
+        "apiToken"              | "apiToken"                  | "testToken1"             | "String"
+        "apiToken"              | "apiToken.set"              | "testToken2"             | "String"
+        "apiToken"              | "apiToken.set"              | "testToken3"             | "Provider<String>"
+        "apiToken"              | "setApiToken"               | "testToken4"             | "String"
+        "apiToken"              | "setApiToken"               | "testToken5"             | "Provider<String>"
+        "owner"                 | "owner"                     | "owner1"                 | "String"
+        "owner"                 | "owner.set"                 | "owner2"                 | "String"
+        "owner"                 | "owner.set"                 | "owner3"                 | "Provider<String>"
+        "owner"                 | "setOwner"                  | "owner4"                 | "String"
+        "owner"                 | "setOwner"                  | "owner5"                 | "Provider<String>"
+        "applicationIdentifier" | "applicationIdentifier"     | "applicationIdentifier1" | "String"
+        "applicationIdentifier" | "applicationIdentifier.set" | "applicationIdentifier2" | "String"
+        "applicationIdentifier" | "applicationIdentifier.set" | "applicationIdentifier3" | "Provider<String>"
+        "applicationIdentifier" | "setApplicationIdentifier"  | "applicationIdentifier4" | "String"
+        "applicationIdentifier" | "setApplicationIdentifier"  | "applicationIdentifier5" | "Provider<String>"
+        value = wrapValueBasedOnType(rawValue, type)
+    }
+
+
     @Unroll()
     def "can add publish destinations with :#method and type '#type'"() {
         given: "a custom task to print extension property"

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
@@ -285,6 +285,78 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         value = wrapValueBasedOnType(rawValue, type)
     }
 
+    @Unroll
+    def "can set property :#property with :#method and type '#type'"() {
+        given: "a task to print publishAppCenter properties"
+        buildFile << """
+            task(custom) {
+                doLast {
+                    def value = publishAppCenter.${property}.get()
+                    println("publishAppCenter.${property}: " + value)
+                }
+            }
+        """
+
+        and: "the test value with replace placeholders"
+        if (value instanceof String) {
+            value = value.replaceAll("#projectDir#", escapedPath(projectDir.path))
+        }
+
+        and: "some configured property"
+        buildFile << "publishAppCenter.${method}(${value})"
+
+        when: ""
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        if (property == "binary") {
+            rawValue = new File(rawValue.replaceAll("#projectDir#", escapedPath(projectDir.path))).path
+        }
+
+        result.standardOutput.contains("publishAppCenter.${property}: ${rawValue}")
+
+        where:
+        property                | method                      | rawValue                     | type
+        "apiToken"              | "apiToken"                  | "testToken1"                 | "String"
+        "apiToken"              | "apiToken.set"              | "testToken2"                 | "String"
+        "apiToken"              | "apiToken.set"              | "testToken3"                 | "Provider<String>"
+        "apiToken"              | "setApiToken"               | "testToken4"                 | "String"
+        "apiToken"              | "setApiToken"               | "testToken5"                 | "Provider<String>"
+        "owner"                 | "owner"                     | "owner1"                     | "String"
+        "owner"                 | "owner.set"                 | "owner2"                     | "String"
+        "owner"                 | "owner.set"                 | "owner3"                     | "Provider<String>"
+        "owner"                 | "setOwner"                  | "owner4"                     | "String"
+        "owner"                 | "setOwner"                  | "owner5"                     | "Provider<String>"
+        "buildVersion"          | "buildVersion"              | "buildVersion1"              | "String"
+        "buildVersion"          | "buildVersion.set"          | "buildVersion2"              | "String"
+        "buildVersion"          | "buildVersion.set"          | "buildVersion3"              | "Provider<String>"
+        "buildVersion"          | "setBuildVersion"           | "buildVersion4"              | "String"
+        "buildVersion"          | "setBuildVersion"           | "buildVersion5"              | "Provider<String>"
+        "releaseId"             | "releaseId"                 | 1                            | "Integer"
+        "releaseId"             | "releaseId.set"             | 2                            | "Integer"
+        "releaseId"             | "releaseId.set"             | 3                            | "Provider<Integer>"
+        "releaseId"             | "setReleaseId"              | 4                            | "Integer"
+        "releaseId"             | "setReleaseId"              | 5                            | "Provider<Integer>"
+        "applicationIdentifier" | "applicationIdentifier"     | "applicationIdentifier1"     | "String"
+        "applicationIdentifier" | "applicationIdentifier.set" | "applicationIdentifier2"     | "String"
+        "applicationIdentifier" | "applicationIdentifier.set" | "applicationIdentifier3"     | "Provider<String>"
+        "applicationIdentifier" | "setApplicationIdentifier"  | "applicationIdentifier4"     | "String"
+        "applicationIdentifier" | "setApplicationIdentifier"  | "applicationIdentifier5"     | "Provider<String>"
+        "releaseNotes"          | "releaseNotes"              | "releaseNotes1"              | "String"
+        "releaseNotes"          | "releaseNotes.set"          | "releaseNotes2"              | "String"
+        "releaseNotes"          | "releaseNotes.set"          | "releaseNotes3"              | "Provider<String>"
+        "releaseNotes"          | "setReleaseNotes"           | "releaseNotes4"              | "String"
+        "releaseNotes"          | "setReleaseNotes"           | "releaseNotes5"              | "Provider<String>"
+        "binary"                | "binary"                    | "#projectDir#/some/binary/1" | "String"
+        "binary"                | "binary"                    | "#projectDir#/some/binary/2" | "File"
+        "binary"                | "binary.set"                | "#projectDir#/some/binary/3" | "File"
+        "binary"                | "binary.set"                | "#projectDir#/some/binary/4" | "Provider<RegularFile>"
+        "binary"                | "setBinary"                 | "#projectDir#/some/binary/5" | "String"
+        "binary"                | "setBinary"                 | "#projectDir#/some/binary/6" | "File"
+        "binary"                | "setBinary"                 | "#projectDir#/some/binary/7" | "Provider<RegularFile>"
+        value = wrapValueBasedOnType(rawValue, type)
+    }
+
     def "can add publish destinations with :destinationId"() {
         given: "a new group"
         def group = ensureDistributionGroup("TestGroupFromId")

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -145,6 +145,7 @@ class AppCenterUploadTask extends DefaultTask {
 
     void setBinary(String value) {
         binary.set(project.file(value))
+        RegularFile
     }
 
     void setBinary(File value) {

--- a/src/main/groovy/wooga/gradle/compat/ProjectLayout.groovy
+++ b/src/main/groovy/wooga/gradle/compat/ProjectLayout.groovy
@@ -1,11 +1,8 @@
 package wooga.gradle.compat
 
 import org.gradle.api.Project
-import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Provider
 
 class ProjectLayout {
 
@@ -23,15 +20,15 @@ class ProjectLayout {
         (DirectoryProperty) compatFactory.invokeMethod("directoryProperty", null)
     }
 
-    DirectoryProperty directoryProperty(Provider<? extends Directory> var1) {
-        (DirectoryProperty) compatFactory.invokeMethod("directoryProperty", var1)
-    }
+//    DirectoryProperty directoryProperty(Provider<? extends Directory> var1) {
+//        (DirectoryProperty) compatFactory.invokeMethod("directoryProperty", var1)
+//    }
 
     RegularFileProperty fileProperty() {
         (RegularFileProperty) compatFactory.invokeMethod("fileProperty", null)
     }
 
-    RegularFileProperty fileProperty(Provider<? extends RegularFile> var1) {
-        (RegularFileProperty) compatFactory.invokeMethod("fileProperty", var1)
-    }
+//    RegularFileProperty fileProperty(Provider<? extends RegularFile> var1) {
+//        (RegularFileProperty) compatFactory.invokeMethod("fileProperty", var1)
+//    }
 }


### PR DESCRIPTION
## Description

Add missing tests for task and extension properties. This patch adds a few more matrix tests to test property setters with different datatypes.

<img width="1125" alt="Screenshot 2020-05-13 at 15 19 14" src="https://user-images.githubusercontent.com/2523575/81817537-28df2100-952d-11ea-923d-dc9a2c657216.png">


## Changes

* ![IMPROVE] test coverage

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
