### PR TITLE
Add retry logic for upload call

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -28,7 +28,7 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
     }
 
     String envNameFromProperty(String property) {
-        "APP_CENTER_${property.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
+        "APP_CENTER_${property.replaceAll(/([A-Z.])/, "_\$1").toUpperCase()}"
     }
 
     @Unroll()
@@ -129,6 +129,15 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         "publishEnabled"        | false                        | _                                        | false             | PropertyLocation.script
         "publishEnabled"        | true                         | _                                        | null              | PropertyLocation.none
 
+        "retryCount"            | 1                            | _                                        | 1                 | PropertyLocation.property
+        "retryCount"            | 2                            | _                                        | 2                 | PropertyLocation.env
+        "retryCount"            | 4                            | _                                        | 4                 | PropertyLocation.script
+        "retryCount"            | 3                            | _                                        | null              | PropertyLocation.none
+
+        "retryTimeout"          | 1000                         | _                                        | 1000              | PropertyLocation.property
+        "retryTimeout"          | 2000                         | _                                        | 2000              | PropertyLocation.env
+        "retryTimeout"          | 4000                         | _                                        | 4000              | PropertyLocation.script
+        "retryTimeout"          | 5000                         | _                                        | null              | PropertyLocation.none
         testValue = (expectedValue == _) ? value : expectedValue
         reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with '$providedValue'")
     }

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/IntegrationSpec.groovy
@@ -97,6 +97,9 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
             case "List":
                 value = "[${rawValue.collect { '"' + it + '"' }.join(", ")}]"
                 break
+            case "Long":
+                value = "${rawValue}L"
+                break
             default:
                 value = rawValue
         }

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
@@ -354,6 +354,16 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         "binary"                | "setBinary"                 | "#projectDir#/some/binary/5" | "String"
         "binary"                | "setBinary"                 | "#projectDir#/some/binary/6" | "File"
         "binary"                | "setBinary"                 | "#projectDir#/some/binary/7" | "Provider<RegularFile>"
+
+        "retryCount"            | "retryCount"                | 1                            | "Integer"
+        "retryCount"            | "retryCount.set"            | 2                            | "Integer"
+        "retryCount"            | "retryCount.set"            | 3                            | "Provider<Integer>"
+        "retryCount"            | "setRetryCount"             | 4                            | "Integer"
+
+        "retryTimeout"          | "retryTimeout"              | 1000L                        | "Long"
+        "retryTimeout"          | "retryTimeout.set"          | 2000L                        | "Long"
+        "retryTimeout"          | "retryTimeout.set"          | 3000L                        | "Provider<Long>"
+        "retryTimeout"          | "setRetryTimeout"           | 4000L                        | "Long"
         value = wrapValueBasedOnType(rawValue, type)
     }
 
@@ -367,7 +377,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         and: "a dummy ipa binary to upload"
         def testFile = getClass().getClassLoader().getResource("test.ipa").path
         buildFile << """
-            publishAppCenter.binary = "$testFile"
+        publishAppCenter.binary = "$testFile"
         """.stripIndent()
 
         and: "a future version meta file"

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
@@ -36,4 +36,12 @@ class AppCenterConsts {
     static Boolean defaultPublishEnabled = true
     static String PUBLISH_ENABLED_OPTION = "appCenter.publishEnabled"
     static String PUBLISH_ENABLED_ENV_VAR = "APP_CENTER_PUBLISH_ENABLED"
+
+    static Long defaultRetryTimeout = 1000 * 5
+    static String RETRY_TIMEOUT_OPTION = "appCenter.retryTimeout"
+    static String RETRY_TIMEOUT_ENV_VAR = "APP_CENTER_RETRY_TIMEOUT"
+
+    static Integer defaultRetryCount = 3
+    static String RETRY_COUNT_OPTION = "appCenter.retryCount"
+    static String RETRY_COUNT_ENV_VAR = "APP_CENTER_RETRY_COUNT"
 }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.appcenter
 
+
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
@@ -45,4 +46,13 @@ interface AppCenterPluginExtension {
     Property<Boolean> getPublishEnabled()
     Property<Boolean> isPublishEnabled()
     void setPublishEnabled(final boolean enabled)
+
+    Property<Long> getRetryTimeout()
+    void setRetryTimeout(Long value)
+    void retryTimeout(Long value)
+
+    Property<Integer> getRetryCount()
+    void setRetryCount(Integer value)
+    void retryCount(Integer value)
+
 }

--- a/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRest.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRest.groovy
@@ -1,0 +1,44 @@
+package wooga.gradle.appcenter.api
+
+import org.apache.http.HttpEntity
+import org.apache.http.HttpResponse
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.mime.MultipartEntityBuilder
+import org.apache.http.entity.mime.content.FileBody
+import org.gradle.api.GradleException
+
+import java.util.logging.Logger
+
+class AppCenterRest {
+    static Logger logger = Logger.getLogger(AppCenterRest.name)
+
+    static Boolean uploadResources(HttpClient client, String apiToken, String uploadUrl, File binary, Integer retryCount = 0, Long retryTimeout = 0) {
+        HttpPost post = new HttpPost(uploadUrl)
+        FileBody ipa = new FileBody(binary)
+        post.setHeader("X-API-Token", apiToken)
+        HttpEntity content = MultipartEntityBuilder.create()
+                .addPart("ipa", ipa)
+                .build()
+
+        post.setEntity(content)
+        HttpResponse response = client.execute(post)
+
+        if (response.statusLine.statusCode >= 500) {
+            logger.warning("unable to upload to provided upload url ${uploadUrl}".toString())
+            logger.warning(response.statusLine.reasonPhrase)
+
+            if (retryCount > 0) {
+                logger.warning("wait and retry after ${(retryTimeout) / 1000} s".toString())
+                sleep(retryTimeout)
+                return uploadResources(client, apiToken, uploadUrl, binary, retryCount - 1, retryTimeout)
+            }
+        }
+
+        if (response.statusLine.statusCode != 204) {
+            throw new GradleException("unable to upload to provided upload url ${uploadUrl}" + response.statusLine.toString())
+        }
+
+        true
+    }
+}

--- a/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
@@ -1,5 +1,6 @@
 package wooga.gradle.appcenter.internal
 
+
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -11,6 +12,8 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
     final Property<String> applicationIdentifier
     final ListProperty<Map<String, String>> defaultDestinations
     final Property<Boolean> publishEnabled
+    final Property<Long> retryTimeout
+    final Property<Integer> retryCount
 
     DefaultAppCenterPluginExtension(Project project) {
         apiToken = project.objects.property(String)
@@ -18,6 +21,9 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
         applicationIdentifier = project.objects.property(String)
         defaultDestinations = project.objects.listProperty(Map)
         publishEnabled = project.objects.property(Boolean)
+        retryTimeout = project.objects.property(Long)
+        retryCount = project.objects.property(Integer)
+
     }
 
     @Override
@@ -88,5 +94,25 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
     @Override
     void setPublishEnabled(boolean enabled) {
         this.publishEnabled.set(enabled)
+    }
+
+    @Override
+    void setRetryTimeout(Long value) {
+        this.retryTimeout.set(value)
+    }
+
+    @Override
+    void retryTimeout(Long value) {
+        setRetryTimeout(value)
+    }
+
+    @Override
+    void setRetryCount(Integer value) {
+        retryCount.set(value)
+    }
+
+    @Override
+    void retryCount(Integer value) {
+        setRetryTimeout(value)
     }
 }

--- a/src/test/groovy/wooga/gradle/appcenter/api/AppCenterRestSpec.groovy
+++ b/src/test/groovy/wooga/gradle/appcenter/api/AppCenterRestSpec.groovy
@@ -1,0 +1,98 @@
+package wooga.gradle.appcenter.api
+
+import org.apache.http.HttpResponse
+import org.apache.http.StatusLine
+import org.apache.http.client.HttpClient
+import org.gradle.api.GradleException
+import spock.lang.Specification
+
+class AppCenterRestSpec extends Specification {
+
+    def httpClient = Mock(HttpClient)
+    def statusLine = Mock(StatusLine)
+    def response = Mock(HttpResponse)
+
+    def setup() {
+        response.statusLine >> statusLine
+        statusLine.reasonPhrase >> "some error reason"
+
+    }
+
+    def "uploadResources fails with exception when status code is not 204"() {
+        given:
+        statusLine.statusCode >> 404
+        httpClient.execute(_) >> response
+
+        when:
+        AppCenterRest.uploadResources(httpClient, "", "", File.createTempFile("test", "binary"))
+
+        then:
+        def e = thrown(GradleException)
+        e.message.startsWith("unable to upload to provided upload url")
+    }
+
+    def "uploadResources throws no exception when status code is 204"() {
+        given:
+        statusLine.statusCode >> 204
+        httpClient.execute(_) >> response
+
+        when:
+        AppCenterRest.uploadResources(httpClient, "", "", File.createTempFile("test", "binary"))
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "uploadResources retries when status code is >= 500"() {
+        given:
+        statusLine.statusCode >> 503
+        6 * httpClient.execute(_) >> response
+
+        when:
+        AppCenterRest.uploadResources(httpClient, "", "", File.createTempFile("test", "binary"), 5)
+
+        then:
+        def e = thrown(GradleException)
+        e.message.startsWith("unable to upload to provided upload url")
+    }
+
+    def "uploadResources retries with timeout when status code is >= 500"() {
+        given:
+        statusLine.statusCode >> 503
+        4 * httpClient.execute(_) >> response
+
+        when:
+        def startTime = System.currentTimeMillis()
+        AppCenterRest.uploadResources(httpClient, "", "", File.createTempFile("test", "binary"), retryCount, retryTimeout)
+
+        then:
+        thrown(GradleException)
+        def duration = System.currentTimeMillis() - startTime
+        duration >= expectedDuration - 200 && duration <= expectedDuration + 200
+
+        where:
+        retryCount | retryTimeout
+        3          | 2000
+        expectedDuration = retryTimeout * retryCount
+    }
+
+    def "uploadResources retries until retryCount or success"() {
+        given:
+        statusLine.statusCode >>> [503, 500, 204]
+        3 * httpClient.execute(_) >> response
+
+        when:
+        def startTime = System.currentTimeMillis()
+        AppCenterRest.uploadResources(httpClient, "", "", File.createTempFile("test", "binary"), retryCount, retryTimeout)
+
+        then:
+        noExceptionThrown()
+        def duration = System.currentTimeMillis() - startTime
+        duration >= expectedDuration - 200 && duration <= expectedDuration + 200
+
+        where:
+        retryCount | retryTimeout | actualRetries
+        3          | 2000         | 2
+        expectedDuration = retryTimeout * actualRetries
+    }
+}


### PR DESCRIPTION
## Description

It happens quite often that the binary upload call fails with an error in the 500 range. I have no real idea what the root cause is since it's a server error. Maybe the inital `createUploadResource` resource call is to blame. This patch adds a simple retry logic around the upload task to check if our errors go down when we try to redo the call a few times with a timeout in between.

The values for retryCount and retryTimeout can be passed as usual via properties, env or directly in script.

| property              | gradle property name              | environment variable                |
| --------------------- | --------------------------------- | ----------------------------------- |
| retryCount            | `appCenter.retryCount`            | `APP_CENTER_RETRY_COUNT`            |
| retryTimeout          | `appCenter.retryTimeout`          | `APP_CENTER_RETRY_TIMEOUT`          |

The default values are `3` for the `retryCount` and `5` seconds for the `retryTimeout`.

To test the logic I had to split the actual call into a helper method. It would be cleaner to also move the other methods over but I treat this change as a temp fix than a proper implemenation. Maybe I roll this back
...

## Changes

* ![ADD] retry logic for upload call


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
