### PR TITLE
Refactor Uploader

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -1,5 +1,6 @@
 package wooga.gradle.appcenter
 
+
 import spock.lang.Unroll
 
 class AppCenterPluginIntegrationSpec extends IntegrationSpec {
@@ -132,12 +133,12 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         "retryCount"            | 1                            | _                                        | 1                 | PropertyLocation.property
         "retryCount"            | 2                            | _                                        | 2                 | PropertyLocation.env
         "retryCount"            | 4                            | _                                        | 4                 | PropertyLocation.script
-        "retryCount"            | 3                            | _                                        | null              | PropertyLocation.none
+        "retryCount"            | 30                           | _                                        | null              | PropertyLocation.none
 
         "retryTimeout"          | 1000                         | _                                        | 1000              | PropertyLocation.property
         "retryTimeout"          | 2000                         | _                                        | 2000              | PropertyLocation.env
         "retryTimeout"          | 4000                         | _                                        | 4000              | PropertyLocation.script
-        "retryTimeout"          | 5000                         | _                                        | null              | PropertyLocation.none
+        "retryTimeout"          | 60000                        | _                                        | null              | PropertyLocation.none
         testValue = (expectedValue == _) ? value : expectedValue
         reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with '$providedValue'")
     }

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/api/AppCenterReleaseUploaderIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/api/AppCenterReleaseUploaderIntegrationSpec.groovy
@@ -1,0 +1,77 @@
+package wooga.gradle.appcenter.api
+
+import org.apache.http.client.HttpClient
+import org.apache.http.client.HttpRequestRetryHandler
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.protocol.HttpContext
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AppCenterReleaseUploaderIntegrationSpec extends Specification {
+    static String apiToken = System.env["ATLAS_APP_CENTER_INTEGRATION_API_TOKEN"]
+    static String owner = System.env["ATLAS_APP_CENTER_OWNER"]
+    static String applicationIdentifierIos = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER_IOS"]
+    static String applicationIdentifierAndroid = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER_ANDROID"]
+
+    void writeRandomData(File destination, Long fileSize) {
+        def random = new Random()
+        def chunkSize = 1024 * 1024 * 4
+        def chunksToWrite = fileSize / chunkSize
+
+        destination.withDataOutputStream {
+            for (int i = 0; i < chunksToWrite; i++) {
+                def chunk = new byte[chunkSize]
+                random.nextBytes(chunk)
+                it.write(chunk)
+            }
+        }
+    }
+
+    File createBigUploadBinary(File baseBinary, File destinationDir, Long fileSize) {
+        def output = new File(destinationDir, baseBinary.name)
+        def packagePayloadDir = File.createTempDir(baseBinary.name, "payload")
+
+        def ant = new AntBuilder()
+        ant.unzip(src: baseBinary,
+                dest: packagePayloadDir.path,
+                overwrite: "false")
+
+        writeRandomData(new File(packagePayloadDir, "test.bin"), fileSize - baseBinary.size())
+
+        ant.zip(destfile: output.path, basedir: packagePayloadDir.path)
+
+        output
+    }
+
+    @Unroll("uploads big dummy #fileType to AppCenter successfully")
+    def "uploads big artifacts"() {
+        given: "a dummy ipa binary increased in filesize to upload"
+        def testFile = new File(getClass().getClassLoader().getResource(fileName).path)
+        testFile = createBigUploadBinary(testFile, File.createTempDir("testUpload", "fileType"), 1024 * 1024 * desiredFileSize)
+
+        int timeout = 30
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(timeout * 1000)
+                .setConnectionRequestTimeout(timeout * 1000)
+                .setSocketTimeout(timeout * 1000).build()
+
+        HttpClient client = HttpClientBuilder.create()
+                .setDefaultRequestConfig(config)
+                .setServiceUnavailableRetryStrategy(new AppCenterRetryStrategy())
+                .build()
+        def uploader = new AppCenterReleaseUploader(client, owner, applicationIdentifier, apiToken)
+
+        when:
+        uploader.upload(testFile)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        fileType | fileName   | applicationIdentifier        | desiredFileSize
+        "ipa"    | "test.ipa" | applicationIdentifierIos     | 160
+        "apk"    | "test.apk" | applicationIdentifierAndroid | 160
+    }
+}

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
@@ -37,11 +37,11 @@ class AppCenterConsts {
     static String PUBLISH_ENABLED_OPTION = "appCenter.publishEnabled"
     static String PUBLISH_ENABLED_ENV_VAR = "APP_CENTER_PUBLISH_ENABLED"
 
-    static Long defaultRetryTimeout = 1000 * 5
+    static Long defaultRetryTimeout = 1000 * 60
     static String RETRY_TIMEOUT_OPTION = "appCenter.retryTimeout"
     static String RETRY_TIMEOUT_ENV_VAR = "APP_CENTER_RETRY_TIMEOUT"
 
-    static Integer defaultRetryCount = 3
+    static Integer defaultRetryCount = 30
     static String RETRY_COUNT_OPTION = "appCenter.retryCount"
     static String RETRY_COUNT_ENV_VAR = "APP_CENTER_RETRY_COUNT"
 }

--- a/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRest.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRest.groovy
@@ -1,17 +1,7 @@
 package wooga.gradle.appcenter.api
 
-
 import groovy.json.JsonSlurper
-import org.apache.commons.io.FilenameUtils
 import org.apache.http.HttpResponse
-import org.apache.http.client.HttpClient
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.utils.URIBuilder
-import org.apache.http.entity.ByteArrayEntity
-import org.apache.http.entity.ContentType
-import org.gradle.api.GradleException
-
-import java.util.logging.Logger
 
 class AppCenterRest {
 
@@ -55,7 +45,7 @@ class AppCenterRest {
         }
     }
 
-    static final API_BASE_URL = "https://api.appcenter.ms/v0.1/apps/"
+    static final API_BASE_URL = "https://api.appcenter.ms/v0.1/apps"
 
     static Map getResponseBody(HttpResponse response) {
         def jsonSlurper = new JsonSlurper()

--- a/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRetryStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRetryStrategy.groovy
@@ -1,0 +1,44 @@
+package wooga.gradle.appcenter.api
+
+import org.apache.http.HttpResponse
+import org.apache.http.HttpStatus
+import org.apache.http.client.ServiceUnavailableRetryStrategy
+import org.apache.http.protocol.HttpContext
+import org.apache.http.util.Args
+
+class AppCenterRetryStrategy implements ServiceUnavailableRetryStrategy {
+    /**
+     * Maximum number of allowed retries if the server responds with a HTTP code
+     * in our retry code list. Default value is 1.
+     */
+    private final int maxRetries;
+
+    /**
+     * Retry interval between subsequent requests, in milliseconds. Default
+     * value is 1 second.
+     */
+    private final long retryInterval;
+
+    AppCenterRetryStrategy(final Integer maxRetries, final Integer retryInterval) {
+        super();
+        Args.positive(maxRetries, "Max retries");
+        Args.positive(retryInterval, "Retry interval");
+        this.maxRetries = maxRetries;
+        this.retryInterval = retryInterval;
+    }
+
+    AppCenterRetryStrategy() {
+        this(30, 1000 * 60);
+    }
+
+    @Override
+    boolean retryRequest(final HttpResponse response, final int executionCount, final HttpContext context) {
+        return executionCount <= maxRetries &&
+                (response.getStatusLine().getStatusCode() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatusLine().getStatusCode() == 429)
+    }
+
+    @Override
+    long getRetryInterval() {
+        return retryInterval;
+    }
+}


### PR DESCRIPTION
Description
===========

A general refactoring to cleanup the uploader and remove the custom retry handling inside of the uploader. Instead use a custom `ServiceUnavailableRetryStrategy` instance to handle the retry with `apache.http`. This PR also adjusts the overall uplaoder API to split optional settings from mandatory values.

Changes
=======

* ![IMPROVE] uploader API and split optional from mandatory settings.
* ![IMPROVE] move retry logic to custom `ServiceUnavailableRetryStrategy` implementation

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
