### PR TITLE
Improve release id polling rate

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/api/AppCenterReleaseUploader.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/api/AppCenterReleaseUploader.groovy
@@ -242,7 +242,7 @@ class AppCenterReleaseUploader {
                             break
                         default:
                             logger.info("wait and poll for releaseId again")
-                            sleep(2000)
+                            sleep(4000)
                             break
                     }
                     break


### PR DESCRIPTION
## Description

From the latest message from appcenter support:

> Hi Manne,
>
> One thing I was thinking about is for you to try spacing further the polling for the releaseID. 1s should be ok for a small infrastructure but you might want to try 2 or 4s... and see if that reduce the number of 429s from the server.
>
> Happy holidays!
> Clement

I adjusted the timeout to 4s. I did not yet make this value configuable.

## Changes

* ![IMPROVE] pollingrate for release id

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
