### PR TITLE
Implement simple retry logic in case of app extracting error

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRetryStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/api/AppCenterRetryStrategy.groovy
@@ -28,7 +28,7 @@ class AppCenterRetryStrategy implements ServiceUnavailableRetryStrategy {
     }
 
     AppCenterRetryStrategy() {
-        this(30, 1000 * 60);
+        this(30, 1000 * 10);
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/appcenter/error/AppCenterUploadException.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/error/AppCenterUploadException.groovy
@@ -1,0 +1,19 @@
+package wooga.gradle.appcenter.error
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class AppCenterUploadException extends Exception {
+}
+
+@InheritConstructors
+class AppCenterAppExtractionException extends Exception {
+
+}
+
+@InheritConstructors
+class AppCenterMalwareDetectionException extends Exception {
+
+}
+
+

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -219,8 +219,6 @@ class AppCenterUploadTask extends DefaultTask {
         AppCenterReleaseUploader.DistributionSettings distributionSettings = uploader.distributionSettings
         AppCenterReleaseUploader.UploadVersion version = uploader.version
 
-        uploader.retrySettings.timeout = retryTimeout.get()
-        uploader.retrySettings.maxRetries = retryCount.get()
         version.buildNumber = buildNumber.getOrNull()
         version.buildVersion = buildVersion.getOrNull()
 


### PR DESCRIPTION
## Description

Appcenter returns an error every now and then `A problem occured while extracting your app`. This seems to be an internal issue as the support was not yet able to help out with this error. Under normal condidtion we trigger a rebuild and the upload works again. This little retry addition just checks for this specific error and retries the whole upload up to 3 times.

## Changes

* ![IMPROVE] uploader with retry when app extraction error is thrown

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
