### PR TITLE
Improve upload stability by retry upload for any server error

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/error/AppCenterUploadException.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/error/AppCenterUploadException.groovy
@@ -8,7 +8,10 @@ class AppCenterUploadException extends Exception {
 
 @InheritConstructors
 class AppCenterAppExtractionException extends Exception {
+}
 
+@InheritConstructors
+class AppCenterAppUploadServerErrorException extends Exception {
 }
 
 @InheritConstructors


### PR DESCRIPTION
## Description

This is my latest attempt to make appcenter more stable. The developers still fight with a list off issues which results in random server errors. I will now add another exception to the retry worthy cases. I only do this for the `releaseID poll` call since this is the one we always see errors and I don't want to rewrite the whole plugin. If this will also not yield better stability I'm inclined to wrap the whole upload in a try catch and repeat each upload multiple times no matter the error.

## Changes

* ![IMPROVE] upload stability by retry upload for any server error

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
