### PR TITLE
Remove coveralls reporting [ATLAS-743]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ withCredentials([string(credentialsId: 'atlas_appcenter_integration_token', vari
                  string(credentialsId: 'atlas_appcenter_integration_application_identifier_android_3', variable: 'appcenterAppIdAndroidLinux'),
 
                  string(credentialsId: 'atlas_appcenter_integration_application_owner', variable: 'appcenterOwner'),
-                 string(credentialsId: 'atlas_appcenter_coveralls_token', variable: 'coveralls_token'),
                  string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
                  string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')
                  ]) {
@@ -40,5 +39,5 @@ withCredentials([string(credentialsId: 'atlas_appcenter_integration_token', vari
                                 ],
                           ]
 
-    buildGradlePlugin platforms: ['macos', 'windows', 'linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment: testEnvironment
+    buildGradlePlugin platforms: ['macos', 'windows', 'linux'], sonarToken: sonar_token, testEnvironment: testEnvironment
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id "net.wooga.plugins" version "3.2.0"
+    id "net.wooga.plugins" version "4.0.0"
     id 'net.wooga.snyk' version '0.10.0'
     id "net.wooga.snyk-gradle-plugin" version "0.2.0"
     id "net.wooga.cve-dependency-resolution" version "0.4.0"


### PR DESCRIPTION
## Description

Because of security issues reported for the coveralls gradle plugin I decided to remove the feature during build. It is not enough to just stop sending reports via jenkins. We also need to update to `net.wooga.plugins` > `4.0.0` because this version removes the dependency.

I remove the coveralls token in the Jenkinsfile so our base pipeline won't try to call the coveralls task on the gradle project.

## Changes

* ![UPDATE] `net.wooga.plugins` to version `4.0.0` to remove coveralls dependency
* ![REMOVE] coveralls token in Jenkinsfile

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"