### PR TITLE
Add extra retry layer at task level [ATLAS-1679]

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -57,7 +57,7 @@ class AppCenterPlugin implements Plugin<Project> {
         extension
     }
 
-    private static void createAndConfigureTasks(Project project, extension) {
+    private static void createAndConfigureTasks(Project project, AppCenterPluginExtension extension) {
         def tasks = project.tasks
 
         def publishAppCenter = tasks.register(PUBLISH_APP_CENTER_TASK_NAME, AppCenterUploadTask, { t ->

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterSpec.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterSpec.groovy
@@ -17,12 +17,11 @@
 package wooga.gradle.appcenter
 
 import com.wooga.gradle.BaseSpec
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
+
 
 trait AppCenterSpec extends BaseSpec {
 

--- a/src/main/groovy/wooga/gradle/appcenter/error/AppCenterUploadException.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/error/AppCenterUploadException.groovy
@@ -19,19 +19,23 @@ package wooga.gradle.appcenter.error
 import groovy.transform.InheritConstructors
 
 @InheritConstructors
-class AppCenterUploadException extends Exception {
+class RetryableException extends RuntimeException {
 }
 
 @InheritConstructors
-class AppCenterAppExtractionException extends Exception {
+class AppCenterUploadException extends RetryableException {
 }
 
 @InheritConstructors
-class AppCenterAppUploadServerErrorException extends Exception {
+class AppCenterAppExtractionException extends RetryableException {
 }
 
 @InheritConstructors
-class AppCenterMalwareDetectionException extends Exception {
+class AppCenterAppUploadServerErrorException extends RetryableException {
+}
+
+@InheritConstructors
+class AppCenterMalwareDetectionException extends RetryableException {
 
 }
 

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterTaskSpec.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterTaskSpec.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.Optional
 import wooga.gradle.appcenter.AppCenterSpec
 import wooga.gradle.appcenter.api.AppCenterBuildInfo
 
+
 import static org.gradle.util.ConfigureUtil.configureUsing
 
 trait AppCenterTaskSpec extends AppCenterSpec {


### PR DESCRIPTION
## Description

~~Retries for the retries god~~
~~Requests for the request throne~~

It seems like the current retry amount is not enough for App Center to consistently upload our stuff. So now there are more retries at the task level, retrying the whole upload process instead of individual requests.  

## Changes
* ![ADD] extra retries at the task level, retrying the whole upload process


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
