### PR TITLE
Add binary and releaseNotes property plus artifact() method to extension [ATLAS-1804]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,5 +52,6 @@ cveHandler {
 dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.httpcomponents:httpmime:4.5.13'
-    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
+    implementation 'com.wooga.gradle:gradle-commons:[2,3)'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[2,3)'
 }

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/IntegrationSpec.groovy
@@ -16,6 +16,7 @@
 
 package wooga.gradle.appcenter
 
+import com.wooga.gradle.test.PropertyUtils
 import groovy.json.StringEscapeUtils
 import nebula.test.functional.ExecutionResult
 
@@ -101,7 +102,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
                 value = "${rawValue}L"
                 break
             default:
-                value = rawValue
+                value = PropertyUtils.wrapValue(rawValue, type)
         }
         value
     }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
@@ -25,9 +25,11 @@ class AppCenterConsts {
     static PropertyLookup owner = new PropertyLookup("APP_CENTER_OWNER", "appCenter.owner", null)
     static PropertyLookup applicationIdentifier = new PropertyLookup("APP_CENTER_APPLICATION_IDENTIFIER", "appCenter.applicationIdentifier", null)
 
-    static PropertyLookup defaultDestinations = new PropertyLookup("APP_CENTER_DEFAULT_DESTINATIONS", "appCenter.defaultDestinations",  "Collaborators")
+    static PropertyLookup defaultDestinations = new PropertyLookup("APP_CENTER_DEFAULT_DESTINATIONS", "appCenter.defaultDestinations", "Collaborators")
 
     static PropertyLookup publishEnabled = new PropertyLookup("APP_CENTER_PUBLISH_ENABLED", "appCenter.publishEnabled", true)
     static PropertyLookup retryTimeout = new PropertyLookup("APP_CENTER_RETRY_TIMEOUT", "appCenter.retryTimeout", 1000 * 60)
     static PropertyLookup retryCount = new PropertyLookup("APP_CENTER_RETRY_COUNT", "appCenter.retryCount", 30)
+    static PropertyLookup binary = new PropertyLookup("APP_CENTER_BINARY", "appCenter.binary", null)
+    static PropertyLookup releaseNotes = new PropertyLookup("APP_CENTER_RELEASE_NOTES", "appCenter.releaseNotes", null)
 }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
@@ -17,11 +17,41 @@
 
 package wooga.gradle.appcenter
 
-
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
 trait AppCenterPluginExtension implements AppCenterSpec {
+
+    abstract void artifact(Provider<PublishArtifact> artifact);
+    abstract void artifact(PublishArtifact artifact);
+
+    private final Property<String> releaseNotes = objects.property(String)
+
+    Property<String> getReleaseNotes() {
+        releaseNotes
+    }
+
+    void setReleaseNotes(Provider<String> value) {
+        releaseNotes.set(value)
+    }
+
+    private final RegularFileProperty binary = objects.fileProperty()
+
+    RegularFileProperty getBinary() {
+        binary
+    }
+
+    void setBinary(Provider<RegularFile> value) {
+        binary.set(value)
+    }
+
+    void setBinary(File value) {
+        binary.set(value)
+    }
 
     // TODO: Refactor, deprecate to use `destinations` instead?
     private final ListProperty<Map<String, String>> defaultDestinations = objects.listProperty(Map)

--- a/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
@@ -17,10 +17,29 @@
 package wooga.gradle.appcenter.internal
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import wooga.gradle.appcenter.AppCenterPluginExtension
 
 class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
 
-    DefaultAppCenterPluginExtension() {
+    private final Project project
+
+    final Property<? extends PublishArtifact> artifact = objects.property(PublishArtifact)
+
+    DefaultAppCenterPluginExtension(Project project) {
+        this.project = project
+    }
+
+
+    @Override
+    void artifact(Provider<PublishArtifact> artifact) {
+        this.artifact.set(artifact)
+    }
+
+    @Override
+    void artifact(PublishArtifact artifact) {
+        this.artifact.set(project.provider{ artifact })
     }
 }


### PR DESCRIPTION
## Description
Right now, we can't configure a publish step in the appCenter plugin without having to insert the release notes and binary into the plugin directly. Plus, the binary is usually given in the format of a gradle artifact. 

With this PR, we insert two new extension properties `appCenter.binary` and `appCenter.releaseNotes` and an `appCenter.artifact(PublishArtifact)` method which uses the given artifact as the binary, and its dependencies are added to `publishAppCenter` dependencies

## Changes
* ![ADD] `appCenter.binary`, `appCenter.releaseNotes` and `appCenter.artifact()` to the extension




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
