### PR TITLE
Add uploadResultMetadata and page_url result metadata field

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -64,9 +64,10 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         }
 
         and: "the test value with replace placeholders"
-        if (testValue instanceof String) {
-            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
+        if (testValue instanceof String && testValue.contains("#projectDir#")) {
+            testValue = new File(testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))).path
         }
+
 
         when: ""
         def result = runTasksSuccessfully("custom")

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/AppCenterPluginIntegrationSpec.groovy
@@ -86,6 +86,16 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         "owner"                 | "'zzz'"                      | "zzz"                                    | "zzz"             | PropertyLocation.script
         "owner"                 | null                         | _                                        | "null"            | PropertyLocation.none
 
+        "binary"                | "xxx"                        | "#projectDir#/build/xxx"                 | "xxx"             | PropertyLocation.env
+        "binary"                | "yyy"                        | "#projectDir#/build/yyy"                 | "yyy"             | PropertyLocation.property
+        "binary"                | "file('zzz')"                | "#projectDir#/zzz"                       | "zzz"             | PropertyLocation.script
+        "binary"                | null                         | _                                        | "null"            | PropertyLocation.none
+
+        "uploadResultMetadata"  | "xxx"                        | "#projectDir#/build/xxx"                 | "xxx"             | PropertyLocation.env
+        "uploadResultMetadata"  | "yyy"                        | "#projectDir#/build/yyy"                 | "yyy"             | PropertyLocation.property
+        "uploadResultMetadata"  | "file('zzz')"                | "#projectDir#/zzz"                       | "zzz"             | PropertyLocation.script
+        "uploadResultMetadata"  | null                         | _                                        | "null"            | PropertyLocation.none
+
         "applicationIdentifier" | "xxx"                        | _                                        | "xxx"             | PropertyLocation.env
         "applicationIdentifier" | "yyy"                        | _                                        | "yyy"             | PropertyLocation.property
         "applicationIdentifier" | "'zzz'"                      | "zzz"                                    | "zzz"             | PropertyLocation.script
@@ -165,13 +175,12 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         buildFile << "appCenter.${method}(${wrapValueBasedOnType(value, type)})"
 
 
-
         when:
         def result = runTasksSuccessfully("custom")
         and:
 
-        if(type.contains("File")) {
-          value = new File(value).path
+        if (type.contains("File")) {
+            value = new File(value).path
         }
 
         then:
@@ -190,6 +199,12 @@ class AppCenterPluginIntegrationSpec extends IntegrationSpec {
         "binary"                | "setBinary"                 | "#projectDir#/bin4"      | "File"
         "binary"                | "setBinary"                 | "#projectDir#/bin4"      | "RegularFile"
         "binary"                | "setBinary"                 | "#projectDir#/bin5"      | "Provider<RegularFile>"
+
+        "uploadResultMetadata"  | "uploadResultMetadata.set"  | "#projectDir#/bin2"      | "RegularFile"
+        "uploadResultMetadata"  | "uploadResultMetadata.set"  | "#projectDir#/bin3"      | "Provider<RegularFile>"
+        "uploadResultMetadata"  | "setUploadResultMetadata"   | "#projectDir#/bin4"      | "File"
+        "uploadResultMetadata"  | "setUploadResultMetadata"   | "#projectDir#/bin4"      | "RegularFile"
+        "uploadResultMetadata"  | "setUploadResultMetadata"   | "#projectDir#/bin5"      | "Provider<RegularFile>"
 
         "releaseNotes"          | "releaseNotes.set"          | "notes2"                 | "String"
         "releaseNotes"          | "releaseNotes.set"          | "notes3"                 | "Provider<String>"

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
@@ -39,15 +39,16 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
     static String owner = System.env["ATLAS_APP_CENTER_OWNER"]
     static String applicationIdentifierIos = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER_IOS"]
     static String applicationIdentifierAndroid = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER_ANDROID"]
+    static String defaultVersionMetaPath = "build/outputs/appCenter/upload_${owner}_${applicationIdentifierIos}.json"
 
     def setup() {
         buildFile << """
             version = "0.1.0"
             ${applyPlugin(AppCenterPlugin)}
-            publishAppCenter.configure { t ->
-                t.owner = "$owner"
-                t.apiToken = "$apiToken"
-                t.applicationIdentifier = "$applicationIdentifierIos"
+            appCenter {
+                owner = "$owner"
+                apiToken = "$apiToken"
+                applicationIdentifier = "$applicationIdentifierIos"
             }
         """.stripIndent()
     }
@@ -134,14 +135,38 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
-        assert !versionMeta.exists()
+        def defaultVersionMeta = new File(projectDir, defaultVersionMetaPath)
+        assert !defaultVersionMeta.exists()
 
         when:
         runTasksSuccessfully("publishAppCenter")
 
         then:
-        versionMeta.exists()
+        defaultVersionMeta.exists()
+    }
+
+    def "writes json file with uploaded version meta data to custom path"() {
+        given: "a dummy ipa binary to upload"
+        def testFile = getClass().getClassLoader().getResource("test.ipa").path
+        def customVersionMetadata = new File(projectDir, "custom_result_metadata.json")
+        buildFile << """
+            appCenter {
+                binary = file("$testFile")
+                uploadResultMetadata = file(${wrapValueBasedOnType(customVersionMetadata, "File")})
+            }
+        """.stripIndent()
+
+        and: "a future version meta file"
+        def defaultVersionMeta = new File(projectDir, defaultVersionMetaPath)
+        assert !defaultVersionMeta.exists()
+        assert !customVersionMetadata.exists()
+
+        when:
+        runTasksSuccessfully("publishAppCenter")
+
+        then:
+        !defaultVersionMeta.exists()
+        customVersionMetadata.exists()
     }
 
     def "publishes to Collaborators group when no groups are configured"() {
@@ -154,7 +179,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         and: "no configured distribution groups"
@@ -188,7 +213,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         when:
@@ -222,7 +247,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         when:
@@ -275,7 +300,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         when:
@@ -308,7 +333,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         when:
@@ -346,7 +371,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         when:
@@ -451,7 +476,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: "a future version meta file"
-        def versionMeta = new File(projectDir, "build/tmp/publishAppCenter/${owner}_${applicationIdentifierIos}.json")
+        def versionMeta = new File(projectDir, defaultVersionMetaPath)
         assert !versionMeta.exists()
 
         when:

--- a/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTaskIntegrationSpec.groovy
@@ -38,8 +38,9 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
     static String apiToken = System.env["ATLAS_APP_CENTER_INTEGRATION_API_TOKEN"]
     static String owner = System.env["ATLAS_APP_CENTER_OWNER"]
     static String applicationIdentifierIos = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER_IOS"]
+    static String applicationIdentifierDefault = applicationIdentifierIos
     static String applicationIdentifierAndroid = System.env["ATLAS_APP_CENTER_INTEGRATION_APPLICATION_IDENTIFIER_ANDROID"]
-    static String defaultVersionMetaPath = "build/outputs/appCenter/upload_${owner}_${applicationIdentifierIos}.json"
+    static String defaultVersionMetaPath = "build/outputs/appCenter/upload_${owner}_${applicationIdentifierDefault}.json"
 
     def setup() {
         buildFile << """
@@ -48,7 +49,7 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
             appCenter {
                 owner = "$owner"
                 apiToken = "$apiToken"
-                applicationIdentifier = "$applicationIdentifierIos"
+                applicationIdentifier = "$applicationIdentifierDefault"
             }
         """.stripIndent()
     }
@@ -143,6 +144,9 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         defaultVersionMeta.exists()
+        and:
+        def versionMetadata = new JsonSlurper().parse(defaultVersionMeta)
+        versionMetadata['page_url'].toString().startsWith("https://install.appcenter.ms/orgs/${owner}/apps/${applicationIdentifierDefault}/releases")
     }
 
     def "writes json file with uploaded version meta data to custom path"() {
@@ -167,6 +171,9 @@ class AppCenterUploadTaskIntegrationSpec extends IntegrationSpec {
         then:
         !defaultVersionMeta.exists()
         customVersionMetadata.exists()
+        and:
+        def versionMetadata = new JsonSlurper().parse(customVersionMetadata)
+        versionMetadata['page_url'].toString().startsWith("https://install.appcenter.ms/orgs/${owner}/apps/${applicationIdentifierDefault}/releases")
     }
 
     def "publishes to Collaborators group when no groups are configured"() {

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterConsts.groovy
@@ -32,4 +32,5 @@ class AppCenterConsts {
     static PropertyLookup retryCount = new PropertyLookup("APP_CENTER_RETRY_COUNT", "appCenter.retryCount", 30)
     static PropertyLookup binary = new PropertyLookup("APP_CENTER_BINARY", "appCenter.binary", null)
     static PropertyLookup releaseNotes = new PropertyLookup("APP_CENTER_RELEASE_NOTES", "appCenter.releaseNotes", null)
+    static PropertyLookup uploadResultMetadata = new PropertyLookup("APP_CENTER_UPLOAD_RESULT_METADATA", "appCenter.uploadResultMetadata", null)
 }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -67,7 +67,7 @@ class AppCenterPlugin implements Plugin<Project> {
         extension.binary.convention(AppCenterConsts.binary.getFileValueProvider(project).orElse(artifactFile))
         extension.releaseNotes.convention(AppCenterConsts.releaseNotes.getStringValueProvider(project))
 
-        def metadataDir = project.layout.buildDirectory.dir("outputs/appcenter")
+        def metadataDir = project.layout.buildDirectory.dir("outputs/appCenter")
         def metadataFile = extension.owner
                 .zip(extension.applicationIdentifier) { owner, appId -> "upload_${owner}_${appId}.json"}
                 .zip(metadataDir) { fileName, dir -> dir.file(fileName) }

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -16,7 +16,6 @@
 
 package wooga.gradle.appcenter
 
-
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.PublishArtifact
@@ -65,9 +64,14 @@ class AppCenterPlugin implements Plugin<Project> {
                 return null
             }
         }
-        extension.binary.convention(artifactFile)
+        extension.binary.convention(AppCenterConsts.binary.getFileValueProvider(project).orElse(artifactFile))
         extension.releaseNotes.convention(AppCenterConsts.releaseNotes.getStringValueProvider(project))
 
+        def metadataDir = project.layout.buildDirectory.dir("outputs/appcenter")
+        def metadataFile = extension.owner
+                .zip(extension.applicationIdentifier) { owner, appId -> "upload_${owner}_${appId}.json"}
+                .zip(metadataDir) { fileName, dir -> dir.file(fileName) }
+        extension.uploadResultMetadata.convention(AppCenterConsts.uploadResultMetadata.getFileValueProvider(project).orElse(metadataFile))
         return extension
     }
 
@@ -91,6 +95,7 @@ class AppCenterPlugin implements Plugin<Project> {
             if(extension.artifact.present && !t.binary.present) {
                 dependsOn(extension.artifact.get().buildDependencies)
             }
+            t.uploadVersionMetaData.convention(extension.uploadResultMetadata)
         }
         project.afterEvaluate {
             if (extension.isPublishEnabled().get()) {

--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
@@ -23,6 +23,9 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
 
 trait AppCenterPluginExtension implements AppCenterSpec {
 
@@ -52,6 +55,26 @@ trait AppCenterPluginExtension implements AppCenterSpec {
     void setBinary(File value) {
         binary.set(value)
     }
+
+
+    private final RegularFileProperty uploadResultMetadata = objects.fileProperty()
+
+    RegularFileProperty getUploadResultMetadata() {
+        return uploadResultMetadata
+    }
+
+    void setUploadResultMetadata(Provider<RegularFile> uploadResultMetadata) {
+        this.uploadResultMetadata.set(uploadResultMetadata)
+    }
+
+    void setUploadResultMetadata(RegularFile uploadResultMetadata) {
+        this.uploadResultMetadata.set(uploadResultMetadata)
+    }
+
+    void setUploadResultMetadata(File uploadResultMetadata) {
+        this.uploadResultMetadata.set(uploadResultMetadata)
+    }
+
 
     // TODO: Refactor, deprecate to use `destinations` instead?
     private final ListProperty<Map<String, String>> defaultDestinations = objects.listProperty(Map)

--- a/src/main/groovy/wooga/gradle/appcenter/api/AppCenterReleaseUploader.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/api/AppCenterReleaseUploader.groovy
@@ -62,7 +62,7 @@ class AppCenterReleaseUploader {
 
         UploadResult(Map release) {
             this.release = release
-            this.releaseID = release['release_Id']
+            this.releaseID = release['id']
             this.downloadUrl = release["download_url"].toString()
             this.installUrl = release["install_url"].toString()
         }

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -24,6 +24,7 @@ import org.apache.http.impl.client.HttpClientBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
@@ -36,20 +37,11 @@ import java.util.function.Supplier
 
 class AppCenterUploadTask extends DefaultTask implements AppCenterTaskSpec {
 
-    private final DirectoryProperty outputDir
-
-    @Internal
-    protected DirectoryProperty getOutputDir() {
-        outputDir
-    }
-
     @OutputFile
-    final Provider<RegularFile> uploadVersionMetaData
+    final RegularFileProperty uploadVersionMetaData = objects.fileProperty()
+
 
     AppCenterUploadTask() {
-        outputDir = project.objects.directoryProperty()
-        outputDir.set(temporaryDir)
-        uploadVersionMetaData = outputDir.file(owner.map({ owner -> "${owner}_${applicationIdentifier.get()}.json" }))
     }
 
     @TaskAction

--- a/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/tasks/AppCenterUploadTask.groovy
@@ -58,9 +58,11 @@ class AppCenterUploadTask extends DefaultTask implements AppCenterTaskSpec {
             .setServiceUnavailableRetryStrategy(new AppCenterRetryStrategy(retryCount.get(), retryTimeout.get().toInteger()))
             .build()
 
+        def owner = owner.get()
+        def appId = applicationIdentifier.get()
         AppCenterReleaseUploader uploader = new AppCenterReleaseUploader(client,
-            owner.get(),
-            applicationIdentifier.get(),
+            owner,
+            appId,
             apiToken.get())
 
         AppCenterReleaseUploader.DistributionSettings distributionSettings = uploader.distributionSettings
@@ -79,7 +81,10 @@ class AppCenterUploadTask extends DefaultTask implements AppCenterTaskSpec {
         logger.info("published to AppCenter release: ${result.releaseID}")
         logger.info("download_url: ${result.downloadUrl}")
         logger.info("install_url: ${result.installUrl}")
-        uploadVersionMetaData.get().asFile << JsonOutput.prettyPrint(JsonOutput.toJson(result.release))
+
+        def uploadVersionMetadataData = new HashMap(result.release)
+        uploadVersionMetadataData['page_url'] = "https://install.appcenter.ms/orgs/${owner}/apps/${appId}/releases/${result.releaseID}"
+        uploadVersionMetaData.get().asFile << JsonOutput.prettyPrint(JsonOutput.toJson(uploadVersionMetadataData))
     }
 
     <T> T retry(int maxRetries, long waitMs, Supplier<T> operation) {


### PR DESCRIPTION
## Description
Exposes the previously internal `ApPCenterUploadTasl.uploadVersionMetaData` Provider as a Property and adds an entry for it in the extension, `appCenter.uploadResultMetadata`. 

Instead of being stored in the task temporary dir, this file nows gets stored by default `build/outputs/appCenter/upload_${owner}_${applicationIdentifierDefault}.json`. The property can be changed for a custom output file. 

Also adds a new metadata in the said result metadata file, the `page_url` field which corresponds to the app center for this upload. 

## Changes
* ![ADD] `uploadResultMetadata` property to `appCenter` extension. 
* ![ADD] `page_url` field to the `uploadResultMetadata` file
* ![FIX] Correct upload ID not being printed by the AppCenterUploadTask tasks
* ![FIX] `appCenter.binary` property wouldn't read from environment/properties




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
