### PR TITLE
Fix artifact bug, Creates new artifact signature in extension

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPluginExtension.groovy
@@ -23,12 +23,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFile
 
 trait AppCenterPluginExtension implements AppCenterSpec {
 
+    abstract void artifact(Object fileLike, Object dependency);
     abstract void artifact(Provider<PublishArtifact> artifact);
     abstract void artifact(PublishArtifact artifact);
 

--- a/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/internal/DefaultAppCenterPluginExtension.groovy
@@ -32,6 +32,30 @@ class DefaultAppCenterPluginExtension implements AppCenterPluginExtension {
         this.project = project
     }
 
+    @Override
+    void artifact(Object fileLike, Object dependency) {
+        def proj = this.project
+        def apks = proj.configurations.create('appCenterBinaries')
+        Provider fileLikeProvider
+        if(fileLike instanceof Provider) {
+            fileLikeProvider = fileLike
+        } else {
+            fileLikeProvider = project.provider { fileLike }
+        }
+
+        def artifact = fileLikeProvider.map { file ->
+            def artifactsSet = apks.artifacts
+            if (artifactsSet.size() > 0) {
+                return artifactsSet.first()
+            } else {
+                return proj.artifacts.add(apks.name, file) {
+                    type 'appCenterArtifact'
+                    builtBy dependency
+                }
+            }
+        } as Provider<PublishArtifact>
+        this.artifact(artifact)
+    }
 
     @Override
     void artifact(Provider<PublishArtifact> artifact) {


### PR DESCRIPTION
## Description
Fixes bug where artifact dependency wouldn't be set to `AppCenterUpload` due to the `binary` property being set by default. 
Adds new signature `appCenter.artifact(file, dependency)` that create an artifact based on a file and a task dependency. 


## Changes
* ![ADD] Adds new signature `appCenter.artifact(file, dependency)`
* ![FIX] Fixes bug where artifact dependency wouldn't be set to `AppCenterUpload`



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
