### PR TITLE
Fix bug where release notes weren't passed into AppCenterUpload

### DIFF
--- a/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/appcenter/AppCenterPlugin.groovy
@@ -82,6 +82,7 @@ class AppCenterPlugin implements Plugin<Project> {
             t.retryCount.convention(extension.retryCount)
             t.retryTimeout.convention(extension.retryTimeout)
             t.binary.convention(extension.binary)
+            t.releaseNotes.convention(extension.releaseNotes)
             if(extension.artifact.present && !t.binary.present) {
                 def artifactFile = extension.artifact.map { PublishArtifact it ->
                     try {


### PR DESCRIPTION
## Description
The `appCenter.releaseNotes` property isn't being forwarded to the `appCenterPublish.releaseNotes` property. This causes extension release notes to be ignored by appCenter. 

## Changes
* ![FIX] AppCenter ignoring set release notes.




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
